### PR TITLE
Adapts pk_get_study_list() to the revamped KB API endpoint

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rphenoscape
 Type: Package
 Title: R package to make phenotypic traits from the Phenoscape Knowledgebase available from within R
-Version: 0.1
+Version: 0.1.1
 Authors@R: person("Hong", "Xu", email = "hx23@duke.edu", role = c("aut", "cre"))
 Maintainer: Hong Xu <hx23@duke.edu>
 Description: This package facilitates the interfacing to the Phenoscape Knowledge for searching ontology terms, retrieving term info, and querying data matrices.

--- a/R/pk_get_IRI.R
+++ b/R/pk_get_IRI.R
@@ -1,12 +1,15 @@
 #' Resolve a text term into IRI
 #'
-#' @param text character. The term to be resolved
+#' @param text character. The term to be resolved.
 #' @param as character. Ontology type. For a taxon, use "vto", anatomical structure, "uberon", phenotype, "pato".
 #' @param verbose logical: optional. If TRUE (default), informative messages printed.
 #'
-#' @return character. The resolved IRI.
+#' @return character. The resolved IRI, or the unmodified input `text` if it was already an HTTP URI.
 #' @export
 pk_get_iri <- function(text, as, verbose=FALSE) {
+  # if the query string is already a HTTP URI, return it as the result
+  if (startsWith(text, "http://") || startsWith(text, "https://")) return(text)
+
   mssg(verbose, paste("Querying the IRI for", text, sep = " "))
   as_type <- match.arg(as, c("vto", "uberon", "pato"))
   onto_id <- switch(as_type,

--- a/man/pk_get_iri.Rd
+++ b/man/pk_get_iri.Rd
@@ -7,16 +7,15 @@
 pk_get_iri(text, as, verbose = FALSE)
 }
 \arguments{
-\item{text}{character. The term to be resolved}
+\item{text}{character. The term to be resolved.}
 
 \item{as}{character. Ontology type. For a taxon, use "vto", anatomical structure, "uberon", phenotype, "pato".}
 
 \item{verbose}{logical: optional. If TRUE (default), informative messages printed.}
 }
 \value{
-character. The resolved IRI.
+character. The resolved IRI, or the unmodified input \code{text} if it was already an HTTP URI.
 }
 \description{
 Resolve a text term into IRI
 }
-

--- a/man/pk_get_study_list.Rd
+++ b/man/pk_get_study_list.Rd
@@ -2,28 +2,64 @@
 % Please edit documentation in R/pk_study.R
 \name{pk_get_study_list}
 \alias{pk_get_study_list}
-\title{Query the list of studies by taxa and anatomical entities}
+\title{Query the list of studies by taxa, anatomical entities, and quqlities.}
 \usage{
-pk_get_study_list(taxon, entity, relation = "part of")
+pk_get_study_list(taxon = NA, entity = NA, quality = NA,
+  includeRels = NA, relation = "part of")
 }
 \arguments{
-\item{taxon}{character. The taxon name.}
+\item{taxon}{character. The name of the taxon by which to filter, if any.}
 
-\item{entity}{character. The entity name.}
+\item{entity}{character. The name of the anatomical entity by which to filter, if any.}
 
-\item{relation}{character. Can be chosen from "part of" and "develops from".}
+\item{quality}{character. The name of the phenotypic quality by which to filter, if any.}
+
+\item{includeRels}{character or vector of characters. The names of relationships
+for anatomical entities to include in addition to subtype (\code{is_a}, \code{rdfs:subClassOf}).
+Defaults to \code{"part_of"}. Set to \code{FALSE} to not include any additional relationships.
+Otherwise one or more of \code{"part of"}, \code{"historical homologous to"}, and
+\code{"serially homologous to"}, or set to \code{TRUE} to include all possible ones. It is
+acceptable to use unambiguous prefixes, for example \code{"historical homolog"}.}
+
+\item{relation}{character. Deprecated, for backwards compatibility defaults to
+\code{part of}. Only used if \code{includeRels} is left at its default value.}
 }
 \value{
 data.frame
 }
 \description{
-Return studies containing taxa which are members of the optional input taxon
-expression and are have annotated phenotypes which are relevant to the optional
-input entity expression.
+Return studies that contain taxa which are members of the optional input taxon,
+and characters which have phenotype annotations subsumed by the given entity and quality
+terms.
 }
 \examples{
 \dontrun{
-slist <- pk_get_study_list(taxon = "Ameiurus", entity = "pelvic splint")
-}
-}
+# by default, parts are included
+slist <- pk_get_study_list(taxon = "Siluridae", entity = "fin")
+colnames(slist)
+nrow(slist)
 
+# can also disable parts
+slist <- pk_get_study_list(taxon = "Siluridae", entity = "fin", includeRels = FALSE)
+nrow(slist)
+
+# or filter studies only by entity, including their parts
+slist <- pk_get_study_list(entity = "pelvic fin", includeRels = c("part of"))
+nrow(slist)
+
+# or filter studies only by entity, including their parts
+slist <- pk_get_study_list(entity = "pelvic fin", includeRels = c("part of"))
+nrow(slist)
+
+# including not only parts but also historical and serial homologs
+slist <- pk_get_study_list(entity = "pelvic fin", includeRels = c("part of", "serially homologous to", "historical homologous to"))
+nrow(slist)
+# relationship names can be given as prefixes
+slist1 <- pk_get_study_list(entity = "pelvic fin", includeRels = c("part", "serial", "historical"))
+nrow(slist1) == nrow(slist)
+
+# or apply no filter, obtaining all studies in the KB
+slist <- pk_get_study_list()
+nrow(slist)
+}
+}

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -104,14 +104,76 @@ test_that("Test OnToTrace", {
 #
 test_that("Test getting study information", {
     skip_on_cran()
-    slist <- pk_get_study_list(taxon = "Ameiurus", entity = "pelvic splint")
-    s1 <- pk_get_study_xml('https://scholar.google.com/scholar?q=The+Phylogeny+of+Ictalurid+Catfishes%3A+A+Synthesis+of+Recent+Work&btnG=&hl=en&as_sdt=0%2C42')
-    ss1 <- pk_get_study(s1)
-    sss1 <- pk_get_study_meta(s1)
+    # backwards compatible mode, defaults to including part_of
+    slist1 <- pk_get_study_list(taxon = "Siluridae", entity = "fin")
+    expect_is(slist1, "data.frame")
+    expect_gt(nrow(slist1), 0)
 
-    expect_is(slist, 'data.frame')
+    # only subsumption, no parts or other relationships
+    slist2 <- pk_get_study_list(taxon = "Siluridae", entity = "fin", includeRels = FALSE)
+    expect_is(slist2, "data.frame")
+    expect_gt(nrow(slist2), 0)
+    expect_gt(nrow(slist1), nrow(slist2))
+
+    # all supported relationships
+    slist3 <- pk_get_study_list(taxon = "Siluridae", entity = "fin", includeRels = TRUE)
+    expect_is(slist3, "data.frame")
+    expect_gt(nrow(slist3), 0)
+    expect_gt(nrow(slist3), nrow(slist2))
+    expect_gte(nrow(slist3), nrow(slist1))
+
+    # subsumption and part_of relationships
+    slist4 <- pk_get_study_list(taxon = "Siluridae", entity = "fin", includeRels = c("part of"))
+    expect_is(slist4, "data.frame")
+    expect_gt(nrow(slist4), 0)
+    expect_gt(nrow(slist4), nrow(slist2))
+    expect_equal(nrow(slist4), nrow(slist1))
+
+    # using prefixes for relationship names works
+    slist5 <- pk_get_study_list(taxon = "Siluridae", entity = "fin",
+                                includeRels = c("part", "historical", "serial"))
+    expect_is(slist5, "data.frame")
+    expect_gt(nrow(slist5), 0)
+    expect_gt(nrow(slist5), nrow(slist2))
+    expect_equal(nrow(slist5), nrow(slist3))
+
+    # filtering by quality works as well
+    slist6 <- pk_get_study_list(taxon = "Siluridae", entity = "fin", quality = "size")
+    expect_is(slist6, "data.frame")
+    expect_gt(nrow(slist6), 0)
+    expect_lt(nrow(slist6), nrow(slist4))
+
+    # can also obtain all studies for taxon
+    slist7.1 <- pk_get_study_list(taxon = "Siluriformes")
+    slist7.2 <- pk_get_study_list(taxon = "Siluriformes", includeRels = FALSE)
+    expect_is(slist7.1, "data.frame")
+    expect_gt(nrow(slist7.1), 0)
+    expect_gt(nrow(slist7.1), 2 * nrow(slist3))
+    expect_equal(nrow(slist7.1), nrow(slist7.2))
+
+    # can also obtain all studies for entity
+    slist8.1 <- pk_get_study_list(entity = "pelvic fin")
+    slist8.2 <- pk_get_study_list(entity = "pelvic fin", includeRels = FALSE)
+    slist8.3 <- pk_get_study_list(entity = "pelvic fin", includeRels = c("serial","historical"))
+    expect_is(slist8.1, "data.frame")
+    expect_gt(nrow(slist8.1), nrow(slist3))
+    expect_gt(nrow(slist8.1), nrow(slist7.1))
+    expect_gt(nrow(slist8.1), nrow(slist8.2))
+    expect_gt(nrow(slist8.3), nrow(slist8.2))
+
+    # can also obtain all studies by leaving off all filters
+    slist9 <- pk_get_study_list()
+    expect_is(slist9, "data.frame")
+    expect_gt(nrow(slist9), 0)
+    expect_gt(nrow(slist9), 20 * nrow(slist3))
+
+    s1 <- pk_get_study_xml(slist1[1,"id"])
     expect_is(s1[[1]], 'nexml')
+
+    ss1 <- pk_get_study(s1)
     expect_is(ss1[[1]], 'data.frame')
+
+    sss1 <- pk_get_study_meta(s1)
     expect_is(sss1[[1]], 'list')
     expect_is(sss1[[1]]$id_taxa, 'data.frame')
 


### PR DESCRIPTION
The KB API endpoint for querying studies changed recently from accepting OWL class expressions to accepting only IRIs each for filtering by taxon, entity, and quality.

These changes maintain the same behavior as previously if invoked with a single taxon and a single entity. OWL expressions are no longer allowed.

This change also adds documentation of the new API and examples for different ways of querying.

Fixes #18.