### PR TITLE
Upgrades to RNeXML installed from GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: r
-sudo: required
+cache: packages
+r:
+  - release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,6 @@ Package: rphenoscape
 Type: Package
 Title: R package to make phenotypic traits from the Phenoscape Knowledgebase available from within R
 Version: 0.1
-Date: 2015-09-09
 Authors@R: person("Hong", "Xu", email = "hx23@duke.edu", role = c("aut", "cre"))
 Maintainer: Hong Xu <hx23@duke.edu>
 Description: This package facilitates the interfacing to the Phenoscape Knowledge for searching ontology terms, retrieving term info, and querying data matrices.
@@ -25,4 +24,5 @@ Suggests:
     testthat,
     plyr,
     rmarkdown
+Remotes: ropensci/RNeXML
 RoxygenNote: 5.0.1


### PR DESCRIPTION
The first failure to build the vignette is due to a broken get_characters() function in RNeXML (see ropensci/RNeXML#172). The fixed version hasn't been released to CRAN yet. (The second failure is fixed in #22.)

Closes #19.