### PR TITLE
 Fixes warnings due to httr::content not using default charset

### DIFF
--- a/R/pk_get_IRI.R
+++ b/R/pk_get_IRI.R
@@ -62,7 +62,7 @@ anatomical_id <- function() 'http://purl.obolibrary.org/obo/uberon.owl'
 phenotype_id <- function() 'http://purl.obolibrary.org/obo/pato.owl'
 
 pk_GET <- function(url, query) {
-  res <- httr::GET(url, query = query)
+  res <- httr::GET(url, httr::accept_json(), query = query)
   stop_for_pk_status(res)
   # if content-type is application/json, httr:content() doesn't assume UTF-8
   # encoding if charset isn't provided by the server, arguably erroneously

--- a/R/pk_get_IRI.R
+++ b/R/pk_get_IRI.R
@@ -64,7 +64,15 @@ phenotype_id <- function() 'http://purl.obolibrary.org/obo/pato.owl'
 pk_GET <- function(url, query) {
   res <- httr::GET(url, query = query)
   stop_for_pk_status(res)
-  out <- httr::content(res, as = "text")
+  # if content-type is application/json, httr:content() doesn't assume UTF-8
+  # encoding if charset isn't provided by the server, arguably erroneously
+  # (because specifying a different charset would violate the spec)
+  enc <- NULL
+  if (startsWith(res$headers$`content-type`, "application/json") &&
+      length(grep("charset", res$headers$`content-type`, fixed = TRUE)) == 0) {
+    enc = "UTF-8"
+  }
+  out <- httr::content(res, as = "text", encoding = enc)
 
   jsonlite::fromJSON(out, simplifyVector = TRUE, flatten = TRUE)
 


### PR DESCRIPTION
For content type application/json the spec says that charset can be omitted and if given it must be UTF-8. Unlike many widely used APIs, the Phenoscape KB doesn't provide the charset attribute for `application/json` content, and `httr::content()`, arguably erroneously, does not assume UTF-8 in that case as the charset determined by the spec.

See phenoscape/phenoscape-kb-services#58 for discussion thread.