### PR TITLE
 Corrects some package metadata, requires RNeXML upgrade

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: rphenoscape
 Type: Package
-Title: R package to make phenotypic traits from the Phenoscape Knowledgebase available from within R
+Title: Semantically rich phenotypic traits from the Phenoscape Knowledgebase
 Version: 0.1.1
 Authors@R: person("Hong", "Xu", email = "hx23@duke.edu", role = c("aut", "cre"))
 Maintainer: Hong Xu <hx23@duke.edu>
 Description: This package facilitates the interfacing to the Phenoscape Knowledge for searching ontology terms, retrieving term info, and querying data matrices.
 License: MIT + file LICENSE
 LazyData: TRUE
-URL: https://github.com/xu-hong/rphenoscape
-BugReports: https://github.com/xu-hong/rphenoscape/issues
+URL: https://github.com/rphenoscape/rphenoscape
+BugReports: https://github.com/rphenoscape/rphenoscape/issues
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
 Depends: 
@@ -17,7 +17,7 @@ Imports:
     jsonlite,
     httr,
     dplyr,
-    RNeXML
+    RNeXML (> 2.1.2)
 Suggests: 
     roxygen2,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,9 @@ Package: rphenoscape
 Type: Package
 Title: Semantically rich phenotypic traits from the Phenoscape Knowledgebase
 Version: 0.1.1
-Authors@R: person("Hong", "Xu", email = "hx23@duke.edu", role = c("aut", "cre"))
-Maintainer: Hong Xu <hx23@duke.edu>
+Authors@R: c(person("Hong", "Xu", email = "hx23@duke.edu", role = c("aut", "cre")),
+  person("Hilmar", "Lapp", email = "hilmar.lapp@duke.edu", role = c("aut"),
+         comment = c(ORCID="0000-0001-9107-0714")))
 Description: This package facilitates the interfacing to the Phenoscape Knowledge for searching ontology terms, retrieving term info, and querying data matrices.
 License: MIT + file LICENSE
 LazyData: TRUE


### PR DESCRIPTION
Also adds @hlapp as package co-author, as an alternative (and this would for now be the default), to also changing maintainer role (as proposed in #26).