### PR TITLE
Adds option to build and install vignettes to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,16 @@ The development version of rphenoscape is available on
 package installed on your system, rphenoscape can be installed using:
 
 ``` r
-library(devtools)
-install_github("phenoscape/rphenoscape")
+devtools::install_github("phenoscape/rphenoscape", build_opts=c("--no-manual"))
 library(rphenoscape)
 ```
+
+The option `build_opts` ensures that the vignettes will be built and installed
+as well. This will require a recent version of the knitr and rmarkdown 
+packages. You can install these beforehand, or include the option
+`dependencies=TRUE`. The latter will also install packages otherwise only 
+needed for testing and for generating the help pages, which, if you don't
+develop packages yourself, may be much more than you need.
 
 Character Matrix via Ontotrace
 ------------------------------

--- a/README.rmd
+++ b/README.rmd
@@ -38,13 +38,19 @@ opts_chunk$set(tidy=FALSE, warning=FALSE, message=FALSE, comment = NA, verbose =
 
 
 ```{r, eval = FALSE}
-library(devtools)
-install_github("phenoscape/rphenoscape")
+devtools::install_github("phenoscape/rphenoscape", build_opts=c("--no-manual"))
 library(rphenoscape)
 ```
 ```{r, echo = FALSE}
 library(rphenoscape)
 ```
+
+The option `build_opts` ensures that the vignettes will be built and installed
+as well. This will require a recent version of the knitr and rmarkdown
+packages. You can install these beforehand, or include the option
+`dependencies=TRUE`. The latter will also install packages otherwise only
+needed for testing and for generating the help pages, which, if you don't
+develop packages yourself, may be much more than you need.
 
 ## Character Matrix via Ontotrace
 Use Ontotrace to obtain a character matrix for a taxonomic clade and anatomical region of interest. 

--- a/vignettes/rphenoscape.Rmd
+++ b/vignettes/rphenoscape.Rmd
@@ -33,13 +33,19 @@ opts_chunk$set(tidy=FALSE, warning=FALSE, message=FALSE, comment = NA, verbose =
 
 
 ```{r, eval = FALSE}
-library(devtools)
-install_github("phenoscape/rphenoscape")
+devtools::install_github("phenoscape/rphenoscape", build_opts=c("--no-manual"))
 library(rphenoscape)
 ```
 ```{r, echo = FALSE}
 library(rphenoscape)
 ```
+
+The option `build_opts` ensures that the vignettes will be built and installed
+as well. This will require a recent version of the knitr and rmarkdown
+packages. You can install these beforehand, or include the option
+`dependencies=TRUE`. The latter will also install packages otherwise only
+needed for testing and for generating the help pages, which, if you don't
+develop packages yourself, may be much more than you need.
 
 ## Character Matrix via Ontotrace
 Use Ontotrace to obtain a character matrix for a taxonomic clade and anatomical region of interest. 


### PR DESCRIPTION
When installing with `devtools::install_github()`, by default the vignettes will not be built and thus not be installed either.