### PR TITLE
Fixes filtering of metadata tables returned from RNeXML

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     jsonlite,
     httr,
     dplyr,
-    RNeXML (>= 2.2.0)
+    RNeXML (>= 2.3.0)
 Suggests: 
     roxygen2,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rphenoscape
 Type: Package
 Title: Semantically rich phenotypic traits from the Phenoscape Knowledgebase
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Hong", "Xu", email = "hx23@duke.edu", role = c("aut", "cre")),
   person("Hilmar", "Lapp", email = "hilmar.lapp@duke.edu", role = c("aut"),
          comment = c(ORCID="0000-0001-9107-0714")))

--- a/R/pk_ontotrace.R
+++ b/R/pk_ontotrace.R
@@ -34,13 +34,13 @@ pk_get_ontotrace <- function(nex) {
 pk_get_ontotrace_meta <- function(nex) {
 
   # NULLing out : for the R CMD CHECK
-  rel <- label <- href <- otu <- otus.x <- char <- NULL
+  property <- label <- href <- otu <- otus.x <- char <- NULL
 
   id_taxa <- get_taxa(nex)
   id_taxa_meta <- get_metadata(nex, "otu")
 
   id_taxa <- (id_taxa_meta
-              %>% filter(rel == meta_attr_taxon)
+              %>% filter(property == meta_attr_taxon)
               %>% inner_join(id_taxa, by = c("otu" = "otu"))
               %>% select(label, href, otu, otus.x)
               %>% rename(otus = otus.x))
@@ -49,7 +49,7 @@ pk_get_ontotrace_meta <- function(nex) {
   id_entities_meta <- get_metadata(nex, level="characters/format/char")
 
   id_entities <- (id_entities_meta
-                  %>% filter(rel == meta_attr_entitiy)
+                  %>% filter(property == meta_attr_entitiy)
                   %>% inner_join(id_entities, by = c("char" = "char"))
                   %>% select(label, href, char))
 

--- a/R/pk_study.R
+++ b/R/pk_study.R
@@ -205,13 +205,13 @@ pk_get_study_by_one <- function(nex) {
 pk_get_study_meta_by_one <- function(nex) {
 
   # NULLing out : for the R CMD CHECK
-  rel <- label <- href <- otu <- otus.x <- char <- NULL
+  property <- label <- href <- otu <- otus.x <- char <- NULL
 
   id_taxa <- get_taxa(nex)
   id_taxa_meta <- get_metadata(nex, "otu")
 
   id_taxa <- (id_taxa_meta
-              %>% filter(rel == meta_attr_taxon)
+              %>% filter(property == meta_attr_taxon)
               %>% inner_join(id_taxa, by = c("otu" = "otu"))
               %>% select(label, href, otu, otus.x)
               %>% rename(otus = otus.x))

--- a/vignettes/rphenoscape.Rmd
+++ b/vignettes/rphenoscape.Rmd
@@ -19,14 +19,8 @@ The development version of rphenoscape is available on [Github](www.github.com/p
 ## Set the paths for cache and figure
 library(methods)
 library(knitr)
-opts_chunk$set(cache = 1)
 basename <- gsub(".Rmd", "", knitr:::knit_concord$get('infile')) 
-opts_chunk$set(fig.path = paste("figure/", basename, "-", sep=""),
-               cache.path = paste("cache/", basename, "/", sep=""))
-```
-
-```{r, echo=FALSE}
-library(knitr)
+opts_chunk$set(fig.path = paste("figure/", basename, "-", sep=""))
 opts_knit$set(upload.fun = imgur_upload)
 opts_chunk$set(tidy=FALSE, warning=FALSE, message=FALSE, comment = NA, verbose = TRUE)
 ```


### PR DESCRIPTION
Beginning with RNeXML 2.3.0, tables returned from `RNeXML::get_metadata()` are simplified by default. We could have forced the old format, but if we need to make a change, then we might as well adapt to the new way of doing things.

As a consequence, we have to require RNeXML 2.3.0 or higher. (New installations of rphenoscape would pull in RNeXML >= 2.3.0 anyway, but upgrading an existing installation of rphenoscape would otherwise not.) 

Fixes #39. (cc @r1t1kg0yal)