### PR TITLE
Fixes markdown so that bullet points render correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ The functionality and operations of the RPhenoscape package can be viewed on the
 
 <http://kb.phenoscape.org/apidocs/>
 
-*Among the functions described on the package website are:* Using Ontotrace to obtain a character matrix Obtaining the character matrices for studies published for a taxonomic clade Subsetting matricies by taxonomic subgroup or anatomical part Searching for details for a given taxon
+Use cases described there include the following:
+
+-   Using Ontotrace to obtain a character matrix
+-   Obtaining the character matrices for studies published for a taxonomic clade
+-   Subsetting matricies by taxonomic subgroup or anatomical part
+-   Searching for details for a given taxon
 
 ------------------------------------------------------------------------
 

--- a/README.rmd
+++ b/README.rmd
@@ -57,11 +57,12 @@ The functionality and operations of the RPhenoscape package can be viewed on the
 
 http://kb.phenoscape.org/apidocs/
 
-*Among the functions described on the package website are:*
-Using Ontotrace to obtain a character matrix
-Obtaining the character matrices for studies published for a taxonomic clade
-Subsetting matricies by taxonomic subgroup or anatomical part
-Searching for details for a given taxon
+Use cases described there include the following:
+
+- Using Ontotrace to obtain a character matrix
+- Obtaining the character matrices for studies published for a taxonomic clade
+- Subsetting matricies by taxonomic subgroup or anatomical part
+- Searching for details for a given taxon
 
 ---
 [![Phenoscape Knowledgebase](https://wiki.phenoscape.org/wg/phenoscape/images/f/f6/Phenoscape_Logo.png)](http://kb.phenoscape.org)


### PR DESCRIPTION
Adds bullet point markup. And apparently there has to be an empty line preceding, or otherwise knitr removes the line breaks and puts it all in one line.