### PR TITLE
 Fixes Ontotrace API wrapper for non-reflexive part_of

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rphenoscape
 Type: Package
 Title: Semantically rich phenotypic traits from the Phenoscape Knowledgebase
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Hong", "Xu", email = "xuhong713@gmail.com", role = "aut"),
   person("Hilmar", "Lapp", email = "hilmar.lapp@duke.edu", role = c("cre", "aut"),
          comment = c(ORCID="0000-0001-9107-0714")))

--- a/R/pk_get_xml.R
+++ b/R/pk_get_xml.R
@@ -1,24 +1,54 @@
-#' Return the NeXML object
+#' Obtain a synthetic presence/absence matrix
+#' 
+#' Queries the Phenoscape KB for a synthetic presence/absence character matrix
+#' for the given taxa and anatomical entities, and returns the result as a
+#' `nexml` object (from the RNeXML package).
+#'
+#' The character matrix includes both asserted and logically inferred states. The
+#' query always includes all subclasses of both taxa and entities, and by default
+#' also includes all parts of the entities. See parameter `relation` for changing
+#' this. By default, only characters that are variable across the resulting taxa
+#' are included; use `variable_only` to change this.
+#' 
 #' @import RNeXML
 #' @import dplyr
-#' @param taxon character: Required. One or a vector of taxon names.
-#' @param entity characters: Required.
+#' @param taxon character, required. A vector of taxon names.
+#' @param entity character, required.
 #'   A single character string or a vector of anatomical class expressions.
-#' @param relation character string: Optional.
+#' @param relation character string, optional.
 #'   The relationship to the entities to be included in the result. Must be
 #'   either "part of" or "develops from", or set to NA to disable.
 #'   Default is "part of".
-#' @param variable_only logical: Optional.
+#' @param variable_only logical, optional.
 #'   Whether to only include characters that are variable across the selected
 #'   set of taxa. Default is TRUE.
-#' @return RNeXML object
+#' @return RNeXML::nexml object
 #' @examples
 #' \dontrun{
-#' nex0 <- pk_get_ontotrace_xml(taxon = "Ictalurus australis", entity = "fin")
-#' }
-#' \dontrun{
+#' # one taxon (including subclasses), one entity (including subclasses and 
+#' # by default its parts)
+#' nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "fin")
+#'
+#' # same as above, except do not include parts or other relationships (fin
+#' # presence/absence does not vary across Ictalurus, hence need to allow
+#' # non-variable characters)
+#' nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "fin",
+#'                             relation = NA, variable_only = FALSE)
+#'
+#' # instead of parts, include entities in develops_from relationship to the query entity
+#' nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "paired fin bud",
+#'                             relation = "develops from", variable_only = FALSE)
+#'
+#' # query with multiple taxa, and/or multiple entities:
 #' nex <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus"),
-#'                             entity = "fin spine")
+#'                             entity = c("pectoral fin", "pelvic fin"))
+#'
+#' # Use the RNeXML API to obtain the character matrix etc:
+#' m <- RNeXML::get_characters(nex)
+#' dim(m)      # number of taxa and characters
+#' rownames(m) # taxon names
+#' colnames(m) # characters (entity names)
+#' 
 #' }
 #' @export
 pk_get_ontotrace_xml <- function(taxon, entity, relation = 'part of', variable_only = TRUE) {

--- a/man/pk_get_ontotrace_xml.Rd
+++ b/man/pk_get_ontotrace_xml.Rd
@@ -8,13 +8,19 @@ pk_get_ontotrace_xml(taxon, entity, relation = "part of",
   variable_only = TRUE)
 }
 \arguments{
-\item{taxon}{character: Required. A single character string or a vector of taxa.}
+\item{taxon}{character: Required. One or a vector of taxon names.}
 
-\item{entity}{characters: Required. A single character string or a vector of anatomical class expressions.}
+\item{entity}{characters: Required.
+A single character string or a vector of anatomical class expressions.}
 
-\item{relation}{character string: Optional. Has to be either "part of" or "develops from". Default is "part of".}
+\item{relation}{character string: Optional.
+The relationship to the entities to be included in the result. Must be
+either "part of" or "develops from", or set to NA to disable.
+Default is "part of".}
 
-\item{variable_only}{logical: Optional. Default is TRUE.}
+\item{variable_only}{logical: Optional.
+Whether to only include characters that are variable across the selected
+set of taxa. Default is TRUE.}
 }
 \value{
 RNeXML object

--- a/man/pk_get_ontotrace_xml.Rd
+++ b/man/pk_get_ontotrace_xml.Rd
@@ -2,13 +2,13 @@
 % Please edit documentation in R/pk_get_xml.R
 \name{pk_get_ontotrace_xml}
 \alias{pk_get_ontotrace_xml}
-\title{Return the NeXML object}
+\title{Obtain a synthetic presence/absence matrix}
 \usage{
 pk_get_ontotrace_xml(taxon, entity, relation = "part of",
   variable_only = TRUE)
 }
 \arguments{
-\item{taxon}{character: Required. One or a vector of taxon names.}
+\item{taxon}{character: Required. A vector of taxon names.}
 
 \item{entity}{characters: Required.
 A single character string or a vector of anatomical class expressions.}
@@ -26,14 +26,42 @@ set of taxa. Default is TRUE.}
 RNeXML object
 }
 \description{
-Return the NeXML object
+Queries the Phenoscape KB for a synthetic presence/absence character matrix
+for the given taxa and anatomical entities, and returns the result as a
+\code{nexml} object (from the RNeXML package).
+}
+\details{
+The character matrix includes both asserted and logically inferred states. The
+query always includes all subclasses of both taxa and entities, and by default
+also includes all parts of the entities. See parameter \code{relation} for changing
+this. By default, only characters that are variable across the resulting taxa
+are included; use \code{variable_only} to change this.
 }
 \examples{
 \dontrun{
-nex0 <- pk_get_ontotrace_xml(taxon = "Ictalurus australis", entity = "fin")
-}
-\dontrun{
+# one taxon (including subclasses), one entity (including subclasses and 
+# by default its parts)
+nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "fin")
+
+# same as above, except do not include parts or other relationships (fin
+# presence/absence does not vary across Ictalurus, hence need to allow
+# non-variable characters)
+nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "fin",
+                            relation = NA, variable_only = FALSE)
+
+# instead of parts, include entities in develops_from relationship to the query entity
+nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "paired fin bud",
+                            relation = "develops from", variable_only = FALSE)
+
+# query with multiple taxa, and/or multiple entities:
 nex <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus"),
-                            entity = "fin spine")
+                            entity = c("pectoral fin", "pelvic fin"))
+
+# Use the RNeXML API to obtain the character matrix etc:
+m <- RNeXML::get_characters(nex)
+dim(m)      # number of taxa and characters
+rownames(m) # taxon names
+colnames(m) # characters (entity names)
+
 }
 }

--- a/tests/testthat/test-ontotrace.R
+++ b/tests/testthat/test-ontotrace.R
@@ -1,0 +1,63 @@
+context("Ontotrace API")
+
+test_that("Ontotrace basics", {
+  skip_on_cran()
+  single_nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "fin")
+  multi_nex <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus"), entity = c("fin spine", "pelvic splint"))
+  
+  testthat::expect_s4_class(single_nex, 'nexml')
+  testthat::expect_s4_class(multi_nex, 'nexml')
+  
+  err1 <- function() pk_get_ontotrace_xml(taxon = "Ictalurus TT", entity = "fin", relation = "other relation")
+  
+  f1 <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus XXX"), entity = c("fin", "spine"))
+  f2 <- pk_get_ontotrace_xml("Ictalurus TT", "fin")
+  
+  expect_error(err1())
+  expect_equal(f1, FALSE)
+  expect_equal(f2, FALSE)
+  
+  single_mat <- pk_get_ontotrace(single_nex)
+  multi_mat <- pk_get_ontotrace(multi_nex)
+  
+  testthat::expect_is(single_mat, 'data.frame')
+  testthat::expect_is(multi_mat, 'data.frame')
+  
+  single_met <- pk_get_ontotrace_meta(single_nex)
+  
+  testthat::expect_is(single_met, 'list')
+  
+})
+
+test_that("relationship expressions", {
+  skip_on_cran()
+  nex1 <- pk_get_ontotrace_xml(taxon = "Ictalurus",
+                               entity = "fin",
+                               variable_only = FALSE)
+  nex2 <- pk_get_ontotrace_xml(taxon = "Ictalurus",
+                               entity = "fin",
+                               relation = "part of",
+                               variable_only = FALSE)
+  nex3 <- pk_get_ontotrace_xml(taxon = "Ictalurus",
+                               entity = "fin",
+                               relation = NA,
+                               variable_only = FALSE)
+  nex1_m <- RNeXML::get_characters(nex1)
+  nex2_m <- RNeXML::get_characters(nex2)
+  nex3_m <- RNeXML::get_characters(nex3)
+  
+  testthat::expect_identical(dim(nex1_m), dim(nex2_m))
+  testthat::expect_identical(nrow(nex1_m), nrow(nex3_m))
+  testthat::expect_lt(ncol(nex3_m), ncol(nex2_m))
+  
+  nex4 <- pk_get_ontotrace_xml(taxon = "Ictalurus",
+                               entity = "paired fin bud",
+                               relation = "develops from",
+                               variable_only = FALSE)
+  nex4_m <- RNeXML::get_characters(nex4)
+  
+  testthat::expect_identical(nrow(nex1_m), nrow(nex4_m))
+  testthat::expect_lt(ncol(nex4_m), ncol(nex2_m))
+  testthat::expect_lt(ncol(nex3_m), ncol(nex4_m))
+  
+})

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -72,35 +72,6 @@ test_that("Test Descendant/Ancestor", {
   expect_equal(tl, c(T, F, F))
 })
 
-test_that("Test OnToTrace", {
-  skip_on_cran()
-  single_nex <- pk_get_ontotrace_xml(taxon = "Ictalurus", entity = "fin")
-  multi_nex <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus"), entity = c("fin spine", "pelvic splint"))
-
-  expect_s4_class(single_nex, 'nexml')
-  expect_s4_class(multi_nex, 'nexml')
-
-  err1 <- function() pk_get_ontotrace_xml(taxon = "Ictalurus TT", entity = "fin", relation = "other relation")
-
-  f1 <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus XXX"), entity = c("fin", "spine"))
-  f2 <- pk_get_ontotrace_xml("Ictalurus TT", "fin")
-
-  expect_error(err1())
-  expect_equal(f1, FALSE)
-  expect_equal(f2, FALSE)
-
-  single_mat <- pk_get_ontotrace(single_nex)
-  multi_mat <- pk_get_ontotrace(multi_nex)
-
-  expect_is(single_mat, 'data.frame')
-  expect_is(multi_mat, 'data.frame')
-
-  single_met <- pk_get_ontotrace_meta(single_nex)
-
-  expect_is(single_met, 'list')
-
-})
-
 #
 test_that("Test getting study information", {
     skip_on_cran()


### PR DESCRIPTION
Also now allows disabling of relationship expression to be incldued, i.e., enables subclasses-only query. Includes tests.

Fixes #55. Fixes #21.