### PR TITLE
Changes handling of definedBy parameter value

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rphenoscape
 Type: Package
 Title: Semantically rich phenotypic traits from the Phenoscape Knowledgebase
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(person("Hong", "Xu", email = "xuhong713@gmail.com", role = "aut"),
   person("Hilmar", "Lapp", email = "hilmar.lapp@duke.edu", role = c("cre", "aut"),
          comment = c(ORCID="0000-0001-9107-0714")))

--- a/R/pk_get_IRI.R
+++ b/R/pk_get_IRI.R
@@ -16,7 +16,7 @@
 #'   pattern. Alternatively, a call expression returning a logical vector, with
 #'   a dot in the position where the `isDefinedBy` value is to be passed.
 #'   The default is an expression that filters out rows with no `isDefinedBy`
-#'   value. 
+#'   value. Can also be set to NA to suppress any filtering by ontology.
 #' @param matchBy character, the term's (metadata) properties against which
 #'   to match. Provide as IRIs or using common namespace prefixes. The default
 #'   is NA, which will use the remote API's default, currently "rdfs:label",
@@ -56,11 +56,7 @@ find_term <- function(query,
   if (is.character(definedBy)) {
     # if definedBy is a list, convert to IRIs those provided as abbreviations
     definedBy <- ontology_iri(definedBy)
-    if (length(definedBy) == 1) {
-      queryseq <- c(queryseq, definedBy = definedBy)
-    } else {
-      definedBy <- rlang::expr(. %in% !!definedBy)
-    }
+    queryseq <- c(queryseq, definedBy = as.character(jsonlite::toJSON(definedBy)))
   }
 
   # if matchBy isn't already an IRI or a list thereof, convert it to one

--- a/man/find_term.Rd
+++ b/man/find_term.Rd
@@ -21,7 +21,7 @@ etc), which will be expanded to full IRIs using the OBO ontology IRI
 pattern. Alternatively, a call expression returning a logical vector, with
 a dot in the position where the \code{isDefinedBy} value is to be passed.
 The default is an expression that filters out rows with no \code{isDefinedBy}
-value.}
+value. Can also be set to NA to suppress any filtering by ontology.}
 
 \item{matchBy}{character, the term's (metadata) properties against which
 to match. Provide as IRIs or using common namespace prefixes. The default


### PR DESCRIPTION
This is due to an update of the KB API, see phenoscape/phenoscape-kb-services#119.