### PR TITLE
Adds option to include parts for ancestor and descendant

### DIFF
--- a/man/pk_is_descendant.Rd
+++ b/man/pk_is_descendant.Rd
@@ -5,14 +5,20 @@
 \alias{pk_is_ancestor}
 \title{Test which candidate terms are ancestors or descendants of a term}
 \usage{
-pk_is_descendant(term, candidates)
+pk_is_descendant(term, candidates, includeRels = c("none", "part_of"))
 
-pk_is_ancestor(term, candidates)
+pk_is_ancestor(term, candidates, includeRels = c("none", "part_of"))
 }
 \arguments{
 \item{term}{character, the label (name) or IRI of the query term}
 
 \item{candidates}{character, the list of candidate term names or IRIs}
+
+\item{includeRels}{character, the relationships R for which to include
+subclasses of expressions "R \emph{some} T", where for \code{is_descendant} T is the
+query term, and for \code{is_ancestor} it is a candidate term.
+At present, the only option is \code{"part_of"}, which will typically only make
+sense for anatomy terms. The default is not to include these.}
 }
 \value{
 A logical vector indicating which candidate terms are ancestors and
@@ -38,7 +44,12 @@ pk_is_ancestor("Sciaenidae", c("Halecostomi", "Abeomelomys", "Sciaenidae"))
 
 # anatomical entities:
 pk_is_descendant("paired fin", c("pectoral fin", "pelvic fin", "dorsal fin"))
+pk_is_descendant("paired fin", c("pelvic fin", "pelvic fin ray")) 
+pk_is_descendant("paired fin", c("pelvic fin", "pelvic fin ray"), includeRels = "part_of")
+
 pk_is_ancestor("pelvic fin", c("paired fin", "hindlimb", "fin"))
+pk_is_ancestor("pelvic fin ray", c("paired fin", "fin"))
+pk_is_ancestor("pelvic fin ray", c("paired fin", "fin"), includeRels = "part_of")
 
 # phenotypic quality
 pk_is_ancestor("triangular", c("shape", "color", "amount"))

--- a/tests/testthat/test-classif.R
+++ b/tests/testthat/test-classif.R
@@ -1,0 +1,56 @@
+context("classification, ancestors, descendants")
+
+test_that("Test getting classification information", {
+  skip_on_cran()
+  t <- pk_taxon_class("Fisherichthys")
+  tt <- pk_taxon_class("Fisherichthys folmeri")
+  
+  a <- pk_anatomical_class("fin")
+  p <- pk_phenotype_class("shape")
+  
+  expect_output(str(t), 'List of 5')
+  expect_output(str(tt), 'List of 5')
+  expect_warning(ttt <- pk_taxon_class("Fisherichthys TT"))
+  expect_true(is.na(ttt))
+  
+  expect_output(str(a), 'List of 5')
+  expect_warning(aa <- pk_anatomical_class("fin FF"))
+  expect_true(is.na(aa))
+  
+  expect_output(str(p), 'List of 5')
+  expect_warning(pp <- pk_phenotype_class("shape SS"))
+  expect_true(is.na(pp))
+  
+})
+
+test_that("descendants/ancestors", {
+  skip_on_cran()
+  
+  # taxon terms:
+  expect_equal(pk_is_descendant("Halecostomi", c("Halecostomi", "Icteria", "Sciaenidae")),
+               c(FALSE, FALSE, TRUE))
+  expect_equal(pk_is_ancestor("Sciaenidae", c("Halecostomi", "Abeomelomys", "Sciaenidae")),
+               c(TRUE, FALSE, FALSE))
+  
+  # anatomical entities:
+  expect_equal(pk_is_descendant("paired fin", c("pectoral fin", "pelvic fin", "dorsal fin")),
+               c(TRUE, TRUE, FALSE))
+  expect_equal(pk_is_descendant("paired fin", c("pelvic fin", "pelvic fin ray")),
+               c(TRUE, FALSE))
+  expect_equal(pk_is_descendant("paired fin", c("pelvic fin", "pelvic fin ray"),
+                                includeRels = "part_of"),
+               c(TRUE, TRUE))
+  expect_equal(pk_is_ancestor("pelvic fin", c("paired fin", "hindlimb", "fin")),
+               c(TRUE, FALSE, TRUE))
+  expect_equal(pk_is_ancestor("pelvic fin ray", c("paired fin", "fin")),
+               c(FALSE, FALSE))
+  expect_equal(pk_is_ancestor("pelvic fin ray", c("paired fin", "fin"),
+                              includeRels = "part_of"),
+               c(TRUE, TRUE))
+
+  # phenotypic quality
+  expect_equal(pk_is_ancestor("triangular", c("shape", "color", "amount")),
+               c(TRUE, FALSE, FALSE))
+  expect_equal(pk_is_descendant("shape", c("T-shaped", "star shaped", "yellow")),
+               c(TRUE, TRUE, FALSE))
+})

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -67,52 +67,6 @@ test_that("Test getting labels", {
   testthat::expect_equal(lbls$id[is.na(lbls$label)], "http://foo")
 })
 
-test_that("Test getting classification information", {
-  skip_on_cran()
-  t <- pk_taxon_class("Fisherichthys")
-  tt <- pk_taxon_class("Fisherichthys folmeri")
-
-  a <- pk_anatomical_class("fin")
-  p <- pk_phenotype_class("shape")
-
-  expect_output(str(t), 'List of 5')
-  expect_output(str(tt), 'List of 5')
-  expect_warning(ttt <- pk_taxon_class("Fisherichthys TT"))
-  expect_true(is.na(ttt))
-
-  expect_output(str(a), 'List of 5')
-  expect_warning(aa <- pk_anatomical_class("fin FF"))
-  expect_true(is.na(aa))
-
-  expect_output(str(p), 'List of 5')
-  expect_warning(pp <- pk_phenotype_class("shape SS"))
-  expect_true(is.na(pp))
-
-})
-
-test_that("Test Descendant/Ancestor", {
-  skip_on_cran()
-
-  # taxon terms:
-  expect_equal(pk_is_descendant("Halecostomi", c("Halecostomi", "Icteria", "Sciaenidae")),
-               c(FALSE, FALSE, TRUE))
-  expect_equal(pk_is_ancestor("Sciaenidae", c("Halecostomi", "Abeomelomys", "Sciaenidae")),
-               c(TRUE, FALSE, FALSE))
-
-  # anatomical entities:
-  expect_equal(pk_is_descendant("paired fin", c("pectoral fin", "pelvic fin", "dorsal fin")),
-               c(TRUE, TRUE, FALSE))
-  expect_equal(pk_is_ancestor("pelvic fin", c("paired fin", "hindlimb", "fin")),
-               c(TRUE, FALSE, TRUE))
-
-  # phenotypic quality
-  expect_equal(pk_is_ancestor("triangular", c("shape", "color", "amount")),
-               c(TRUE, FALSE, FALSE))
-  expect_equal(pk_is_descendant("shape", c("T-shaped", "star shaped", "yellow")),
-               c(TRUE, TRUE, FALSE))
-})
-
-#
 test_that("Test getting study information", {
     skip_on_cran()
     # backwards compatible mode, defaults to including part_of


### PR DESCRIPTION
Includes tests and updates to documentation. See phenoscape/phenoscape-kb-services#134 for KB API change that enables this.