### PR TITLE
Makes get_term_label() more robust and successful

### DIFF
--- a/R/pk_terms.R
+++ b/R/pk_terms.R
@@ -87,30 +87,51 @@ pk_details <- function(term, as, verbose=FALSE) {
 #' @return A data.frame with columns "id" and "label".
 #' @export
 get_term_label <- function(term_iris, preserveOrder = FALSE, verbose = FALSE) {
-  queryseq <- list(iris = paste0(term_iris, collapse = ","))
-  res <- get_json_data(pkb_api("/term/labels"), query = queryseq)
-  res <- res$results
-  if (length(res) == 0) {
-    warning("No labels were found for any of the query terms", call. = FALSE)
-    res <- data.frame(id = term_iris, label = rep(NA, times = length(term_iris)))
+  if (length(term_iris) == 1) {
+    queryseq <- list(iri = term_iris[[1]])
+    res <- get_json_data(pkb_api("/term/label"), query = queryseq)
+    if (identical(res$`@id`, res$label))
+      res <- data.frame(id = term_iris, label = c(NA), stringsAsFactors = FALSE)
+    else
+      res <- as.data.frame(res, check.names = FALSE, stringsAsFactors = FALSE)
   } else {
+    queryseq <- list(iris = paste0(term_iris, collapse = ","))
+    res <- get_json_data(pkb_api("/term/labels"), query = queryseq)
+    res <- res$results
+  }
+  if (length(res) > 0) {
     names(res) <- sub("@", "", names(res))
-    if (nrow(res) < length(term_iris)) {
+  }
+  # /term/labels fails to produce a label for some terms where /term/label can,
+  # so try to fill in labels not previously provided, and warn where that fails
+  if (length(term_iris) > 1 &&
+      (length(res) == 0 || nrow(res) < length(term_iris))) {
+    if (length(res) == 0)
+      iriMap <- rep(NA, times = length(term_iris))
+    else
       iriMap <- match(term_iris, res$id)
-      warning("No label was found for the following input IRIs, substituting NA:\n\t",
-              paste0(term_iris[is.na(iriMap)], collapse = "\n\t"),
+    unmatched <- data.frame(id = term_iris[is.na(iriMap)])
+    unmatched <- cbind(unmatched, label = sapply(unmatched$id, term_label))
+    if (any(is.na(unmatched)))
+      warning("Failed to find label for following input IRIs, substituting NA:\n\t",
+              paste0(unmatched$id[is.na(unmatched$label)], collapse = "\n\t"),
               call. = FALSE)
-      unmatched <- data.frame(id = term_iris[is.na(iriMap)],
-                              label = rep(NA, times = length(term_iris) - nrow(res)))
-      res <- rbind(res, unmatched)
-    }
-    if (preserveOrder && nrow(res) > 0) {
-      reordering <- match(term_iris, res$id)
-      res <- res[reordering,]
-    }
+    res <- rbind(res, unmatched)
+  }
+  if (preserveOrder && nrow(res) > 0) {
+    reordering <- match(term_iris, res$id)
+    res <- res[reordering,]
   }
 
   res
+}
+
+term_label <- function(term_iri) {
+  res <- get_json_data(pkb_api("/term/label"), query = list(iri = term_iri))
+  if (identical(res$`@id`, res$label))
+    NA
+  else
+    res$label
 }
 
 pk_taxon_url <- "http://kb.phenoscape.org/api/taxon"

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -65,6 +65,21 @@ test_that("Test getting labels", {
   testthat::expect_warning(lbls <- get_term_label(c(tt, "http://foo")))
   testthat::expect_equal(sum(is.na(lbls$label)), 1)
   testthat::expect_equal(lbls$id[is.na(lbls$label)], "http://foo")
+
+  lbls <- get_term_label(tt[1])
+  testthat::expect_equal(nrow(lbls), 1)
+  testthat::expect_false(is.na(lbls$label))
+
+  lbls <- get_term_label("foobar")
+  testthat::expect_equal(nrow(lbls), 1)
+  testthat::expect_equal(lbls$id, "foobar")
+  testthat::expect_true(is.na(lbls$label))
+
+  # can retrieve labels that /term/labels can't
+  lbls <- get_term_label(c(tt[1], "http://purl.org/phenoscape/expression?value=%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBFO_0000051%3E+some+%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001062%3E"),
+                         preserveOrder = TRUE)
+  testthat::expect_equal(nrow(lbls), 2)
+  testthat::expect_false(any(is.na(lbls$label)))
 })
 
 test_that("Test getting study information", {


### PR DESCRIPTION
In particular, there are some terms (class expressions) that /term/labels fails to produce a label for. These will be filled in with /term/label where possible. See also phenoscape/phenoscape-kb-services#139.

This also detects the problem reported in phenoscape/phenoscape-kb-services#145 and deals with it.