### PR TITLE
Handles API endpoints returning zero content if no match

### DIFF
--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -27,6 +27,9 @@
 get_json_data <- function(url, query, verbose = FALSE, ensureNames = NULL) {
   res <- httr::GET(url, httr::accept_json(), query = query)
   stop_for_pk_status(res)
+  # some endpoints return zero content for failure to find data
+  if (res$headers$`content-length` == 0) return(NULL)
+
   # if content-type is application/json, httr:content() doesn't assume UTF-8
   # encoding if charset isn't provided by the server, arguably erroneously
   # (because specifying a different charset would violate the spec)


### PR DESCRIPTION
Some of the KB API endpoints return zero-length content if there is no match to the query (instead of, for example, an empty JSON array or list). The problem is that then there is also no content-type header, resulting in an error when testing whether the content-type is JSON. This will catch that condition and return NULL to the caller.