### PR TITLE
Vectorizes pk_taxon_detail and pk_is_extinct

### DIFF
--- a/man/pk_is_extinct.Rd
+++ b/man/pk_is_extinct.Rd
@@ -2,16 +2,24 @@
 % Please edit documentation in R/pk_terms.R
 \name{pk_is_extinct}
 \alias{pk_is_extinct}
-\title{Test if a taxon is extinct.}
+\title{Determine which taxa are extinct}
 \usage{
-pk_is_extinct(taxon)
+pk_is_extinct(taxon, verbose = FALSE)
 }
 \arguments{
-\item{taxon}{character, the taxon name to be tested.}
+\item{taxon}{character, the taxa or list of taxa, as names or IRIs. Names
+will first be looked up, and a warning will be issued for names that fail
+to be found as a taxon name. Names and IRIs can be intermixed.}
+
+\item{verbose}{logical, whether or not to print informative messages for
+possibly time-consuming operations. The default is \code{FALSE}.}
 }
 \value{
-logical, TRUE if extinct, FALSE if not
+A logical named vector with value \code{TRUE} if the corresponding input
+taxon is marked as extinct, and FALSE otherwise. For taxon names that failed
+to be looked up, the value will be NA. Names will be the input taxa where
+there were given as names, and the label of the respective taxon otherwise.
 }
 \description{
-Test if a taxon is extinct.
+This is simply a convenience function on top of \code{\link[=pk_taxon_detail]{pk_taxon_detail()}}.
 }

--- a/man/pk_terms.Rd
+++ b/man/pk_terms.Rd
@@ -14,18 +14,38 @@ pk_anatomical_detail(term, verbose = FALSE)
 
 pk_phenotype_detail(term, verbose = FALSE)
 
-pk_gene_detail(term, verbose = FALSE)
+pk_gene_detail(term, taxon = NA, verbose = FALSE)
 }
 \arguments{
-\item{term}{character. The term to be searched.}
+\item{term}{character, the query term, either as name or IRI. Names are looked
+up against taxonomies, anatomy ontologies, and PATO for \code{pk_taxon_detail},
+\code{pk_anatomical_detail}, and \code{pk_phenotype_detail}, respectively.
 
-\item{verbose}{logical: optional. If TRUE (default), informative messages printed.}
+For \code{pk_taxon_detail} this can also be a list (or vector) of terms (taxa).}
+
+\item{verbose}{logical, whether informative messages should be printed. The
+default is \code{FALSE}.}
+
+\item{taxon}{character, the NCBI taxon name or corresponding NCBITaxon
+ontology IRI for which to match the gene name.}
 }
 \value{
-A data.frame with term id, label, and definition
+A data.frame, with at least columns "id" and "label".
+
+For \code{pk_taxon_detail}, additional columns are "extinct" (logical),
+"rank.id", "rank.label", and where available "common_name". The rows
+corresponding to taxon names that failed to be resolved to IRIs will be NA.
+
+For \code{pk_anatomical_detail} and \code{pk_phenotype_detail}, the additional
+column is "definition".
+
+For \code{pk_gene_detail}, the additional columns are "taxon.id" and "taxon.label"
+for the corresponding NCBI Taxonomy ID and name, and "matchType" ('exact'
+or 'partial').
 }
 \description{
-Retrieve details about a taxon, an anatomical structure, a gene, or a phenotype.
+Retrieve details about a taxon, an anatomical structure, a gene, or a phenotypic
+quality.
 }
 \examples{
 pk_taxon_detail("Coralliozetus")


### PR DESCRIPTION
`pk_is_extinct()` will often be used for matrix subsetting, so benefits from accepting vector input. Because it is just a thin wrapper around `pk_taxon_detail()`, that then needs to be vectorized as well.

Also updates manual pages accordingly.