### PR TITLE
Adds ability to request (phenotype,taxon) tuples

### DIFF
--- a/R/phenotypes.R
+++ b/R/phenotypes.R
@@ -87,10 +87,8 @@ get_phenotypes <- function(entity = NA, quality = NA, taxon = NA, study = NA,
   mssg(verbose, "Querying for phenotypes ...")
   if (is.na(taxon) || ! .withTaxon)
     endp <- "/phenotype/query"
-  else {
+  else
     endp <- "/taxon/annotations"
-    queryseq$limit = "999" # temporary hack due to KB API bug
-  }
   out <- get_json_data(pkb_api(endp), queryseq)
   res <- out$results
   if (length(res) > 0) {

--- a/R/phenotypes.R
+++ b/R/phenotypes.R
@@ -20,6 +20,12 @@
 #'   Otherwise one or more of `"part of"`, `"historical homologous to"`, and
 #'   `"serially homologous to"`, or set to `TRUE` to include all possible ones. It
 #'   is acceptable to use unambiguous prefixes, for example `"historical"`.
+#' @param .withTaxon logical, whether to include taxa in the result if `taxon` is
+#'   provided. If TRUE, only the combination of phenotype and taxon will be
+#'   unique in the returned data frame. Default is FALSE, meaning by default
+#'   providing a value for `taxon` only acts as another filter but does not
+#'   change format or redundancy of the result. Ignored if `taxon` is
+#'   not provided as a character value.
 #' @param verbose logical, whether to print messages informing about potentially
 #'   time-consuming operations. Default is FALSE.
 #' @examples
@@ -40,22 +46,37 @@
 #' phens2 <- get_phenotypes(entity = "pelvic fin", includeRels = TRUE)
 #' table(phens2$id %in% phens1$id)
 #'
-#' # filter by quality
+#' # filter also by quality
 #' phens2 <- get_phenotypes(entity = "pelvic fin", quality = "shape")
 #' table(phens1$id %in% phens2$id)
 #'
-#' # filter by quality and taxon
+#' # filter also by quality and taxon
 #' phens2 <- get_phenotypes(entity = "pelvic fin", quality = "shape", taxon = "Siluriformes")
 #' table(phens1$id %in% phens2$id)
+#'
+#' # filter by entity, quality and taxon, and return taxa as well (resulting in
+#' # (phenotype, taxon) "tuples")
+#' phens2a <- get_phenotypes(entity = "pelvic fin", quality = "shape", taxon = "Siluriformes",
+#'                           .withTaxon = TRUE)
+#' head(phens2a)
+#' nrow(phens2a) - nrow(phens2) # lots of redundancy due to n:n relationship
+#' nrow(unique(phens2a[,c("id", "label")])) == nrow(phens2) # but some #phenotypes
 #'
 #' # can compute and visualize similarity
 #' sm <- jaccard_similarity(terms = phens2$id, .labels = phens2$label, .colnames = "label")
 #' plot(hclust(as.dist(1-sm)))
 #' }
 #' @return A data frame with columns "id" and "label".
+#'
+#'   If a character value for `taxon` was provided, and `.withTaxon` is TRUE’,
+#'   columns "taxon.id" and "taxon.label" will be returned as well. While
+#'   (phenotypes, taxon) tuples will be unique, both phenotypes and taxa
+#'   individually will then be redundant in the returned data frame (the
+#'   association is n:n).
 #' @export
 get_phenotypes <- function(entity = NA, quality = NA, taxon = NA, study = NA,
                            includeRels = c("part of"),
+                           .withTaxon = FALSE,
                            verbose = FALSE) {
   argsInCall <-  as.list(match.call())[-1]
   # need to make sure to apply our defaults where they differ
@@ -64,9 +85,26 @@ get_phenotypes <- function(entity = NA, quality = NA, taxon = NA, study = NA,
   queryseq <- c(queryseq, limit = "1000000")
 
   mssg(verbose, "Querying for phenotypes ...")
-  out <- get_json_data(pkb_api("/phenotype/query"), queryseq)
+  if (is.na(taxon) || ! .withTaxon)
+    endp <- "/phenotype/query"
+  else
+    endp <- "/taxon/annotations"
+  out <- get_json_data(pkb_api(endp), queryseq)
   res <- out$results
-  colnames(res) <- sub("@", "", x = colnames(res))
-
+  if (length(res) > 0) {
+    nms <- sub("@", "", x = colnames(res))
+    isTaxonCol <- startsWith(nms, "taxon")
+    if (any(isTaxonCol)) {
+      # remove 'phenotype' prefix for phenotype ID and label
+      nms <- sub("phenotype.", "", x = nms)
+      # ensure that the additional taxon ID and label columns are last, so
+      # we're only adding columns to the end
+      i <- seq(1, ncol(res))
+      reordering <- c(i[! isTaxonCol], i[isTaxonCol])
+      res <- res[, reordering]
+      nms <- nms[reordering]
+    }
+    colnames(res) <- nms
+  }
   res
 }

--- a/R/phenotypes.R
+++ b/R/phenotypes.R
@@ -87,8 +87,10 @@ get_phenotypes <- function(entity = NA, quality = NA, taxon = NA, study = NA,
   mssg(verbose, "Querying for phenotypes ...")
   if (is.na(taxon) || ! .withTaxon)
     endp <- "/phenotype/query"
-  else
+  else {
     endp <- "/taxon/annotations"
+    queryseq$limit = "999" # temporary hack due to KB API bug
+  }
   out <- get_json_data(pkb_api(endp), queryseq)
   res <- out$results
   if (length(res) > 0) {

--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -28,7 +28,8 @@ get_json_data <- function(url, query, verbose = FALSE, ensureNames = NULL) {
   res <- httr::GET(url, httr::accept_json(), query = query)
   stop_for_pk_status(res)
   # some endpoints return zero content for failure to find data
-  if (res$headers$`content-length` == 0) return(NULL)
+  contLen <- res$headers$`content-length`
+  if ((! is.null(contLen)) && contLen == 0) return(NULL)
 
   # if content-type is application/json, httr:content() doesn't assume UTF-8
   # encoding if charset isn't provided by the server, arguably erroneously

--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -154,6 +154,8 @@ pkb_args_to_query <- function(...,
 
   # entity, quality, taxon, study etc
   argList <- list(...)
+  # remove parameters not meant for us
+  argList <- argList[! startsWith(names(argList), ".")]
   queryseq <- c(queryseq,
                 sapply(names(argList[!is.na(argList)]),
                        function(x) {

--- a/man/get_phenotypes.Rd
+++ b/man/get_phenotypes.Rd
@@ -5,7 +5,7 @@
 \title{Retrieve phenotypes by entity, quality, taxon, and study}
 \usage{
 get_phenotypes(entity = NA, quality = NA, taxon = NA, study = NA,
-  includeRels = c("part of"), verbose = FALSE)
+  includeRels = c("part of"), .withTaxon = FALSE, verbose = FALSE)
 }
 \arguments{
 \item{entity}{character, the anatomical entity by which to filter, if any.}
@@ -23,11 +23,24 @@ Otherwise one or more of \code{"part of"}, \code{"historical homologous to"}, an
 \code{"serially homologous to"}, or set to \code{TRUE} to include all possible ones. It
 is acceptable to use unambiguous prefixes, for example \code{"historical"}.}
 
+\item{.withTaxon}{logical, whether to include taxa in the result if \code{taxon} is
+provided. If TRUE, only the combination of phenotype and taxon will be
+unique in the returned data frame. Default is FALSE, meaning by default
+providing a value for \code{taxon} only acts as another filter but does not
+change format or redundancy of the result. Ignored if \code{taxon} is
+not provided as a character value.}
+
 \item{verbose}{logical, whether to print messages informing about potentially
 time-consuming operations. Default is FALSE.}
 }
 \value{
 A data frame with columns "id" and "label".
+
+If a character value for \code{taxon} was provided, and \code{.withTaxon} is TRUE’,
+columns "taxon.id" and "taxon.label" will be returned as well. While
+(phenotypes, taxon) tuples will be unique, both phenotypes and taxa
+individually will then be redundant in the returned data frame (the
+association is n:n).
 }
 \description{
 Retrieves "semantic phenotypes", i.e., phenotypes encodes as ontological
@@ -60,13 +73,21 @@ table(phens2$id \%in\% phens1$id)
 phens2 <- get_phenotypes(entity = "pelvic fin", includeRels = TRUE)
 table(phens2$id \%in\% phens1$id)
 
-# filter by quality
+# filter also by quality
 phens2 <- get_phenotypes(entity = "pelvic fin", quality = "shape")
 table(phens1$id \%in\% phens2$id)
 
-# filter by quality and taxon
+# filter also by quality and taxon
 phens2 <- get_phenotypes(entity = "pelvic fin", quality = "shape", taxon = "Siluriformes")
 table(phens1$id \%in\% phens2$id)
+
+# filter by entity, quality and taxon, and return taxa as well (resulting in
+# (phenotype, taxon) "tuples")
+phens2a <- get_phenotypes(entity = "pelvic fin", quality = "shape", taxon = "Siluriformes",
+                          .withTaxon = TRUE)
+head(phens2a)
+nrow(phens2a) - nrow(phens2) # lots of redundancy due to n:n relationship
+nrow(unique(phens2a[,c("id", "label")])) == nrow(phens2) # but some #phenotypes
 
 # can compute and visualize similarity
 sm <- jaccard_similarity(terms = phens2$id, .labels = phens2$label, .colnames = "label")


### PR DESCRIPTION
Many downstream comparative analyses will need taxon associations for phenotypes. This change allows requesting (phenoscape, taxon) tuples instead of non-redundant phenotypes, if a taxon filter is provided.

Includes documentation and example.

Addresses #104, possibly in full.