### PR TITLE
Enables switching to POST for JSON-returning queries

### DIFF
--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -25,7 +25,10 @@
 #' @importFrom jsonlite fromJSON
 #' @importFrom httr GET content
 get_json_data <- function(url, query, verbose = FALSE, ensureNames = NULL) {
-  res <- httr::GET(url, httr::accept_json(), query = query)
+  if (nchar(jsonlite::toJSON(query)) >= 2048)
+    res <- httr::POST(url, httr::accept_json(), body = query, encode = "form")
+  else
+    res <- httr::GET(url, httr::accept_json(), query = query)
   stop_for_pk_status(res)
   # some endpoints return zero content for failure to find data
   contLen <- res$headers$`content-length`


### PR DESCRIPTION
This had already been enabled for CSV returning queries.

Note that most KB API methods returning JSON do not actually support POST at this point. However, the expectation is that for those that do not, it is hardly possible to create a query URL (for a GET request) that is too long. The one triggering the issue (/term/labels, see #113) does support POST.

Fixes #113.