### PR TITLE
Adapts obtaining term labels to recent change in KB API

### DIFF
--- a/man/get_term_label.Rd
+++ b/man/get_term_label.Rd
@@ -17,7 +17,9 @@ order.}
 time-consuming operations.}
 }
 \value{
-A data.frame with columns "id" and "label".
+A data.frame with columns "id" and "label". The "id" column contains
+the IRIs. The label will be \code{NA} for term IRIs that are not present in the
+KB, or for which the KB cannot produce a label.
 }
 \description{
 Attempts to obtain the label for each term, identified by IRI, in the input

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -106,7 +106,7 @@ test_that("Test getting labels", {
   lbls <- get_term_label(tt, preserveOrder = TRUE)
   testthat::expect_equal(tt, lbls$id)
 
-  testthat::expect_warning(lbls <- get_term_label(c(tt, "http://foo")))
+  testthat::expect_silent(lbls <- get_term_label(c(tt, "http://foo")))
   testthat::expect_equal(sum(is.na(lbls$label)), 1)
   testthat::expect_equal(lbls$id[is.na(lbls$label)], "http://foo")
 
@@ -114,16 +114,11 @@ test_that("Test getting labels", {
   testthat::expect_equal(nrow(lbls), 1)
   testthat::expect_false(is.na(lbls$label))
 
-  lbls <- get_term_label("foobar")
+  lbls <- get_term_label("urn:foobar")
   testthat::expect_equal(nrow(lbls), 1)
-  testthat::expect_equal(lbls$id, "foobar")
+  testthat::expect_equal(lbls$id, "urn:foobar")
   testthat::expect_true(is.na(lbls$label))
 
-  # can retrieve labels that /term/labels can't
-  lbls <- get_term_label(c(tt[1], "http://purl.org/phenoscape/expression?value=%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FBFO_0000051%3E+some+%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0001062%3E"),
-                         preserveOrder = TRUE)
-  testthat::expect_equal(nrow(lbls), 2)
-  testthat::expect_false(any(is.na(lbls$label)))
 })
 
 test_that("Test getting study information", {


### PR DESCRIPTION
See phenoscape-kb-services#170 for respective KB API changes.

Note that the KB now prepends the base URL of the Blazegraph instance to a query token if it's not an IRI or URN. Hence, we adjust the test for faithfully returning different query terms to only use URNs or IRIs.