### PR TITLE
Allows controlling ontotrace behavior if names fail to resolve

### DIFF
--- a/man/pk_get_ontotrace_xml.Rd
+++ b/man/pk_get_ontotrace_xml.Rd
@@ -5,7 +5,7 @@
 \title{Obtain a synthetic presence/absence matrix}
 \usage{
 pk_get_ontotrace_xml(taxon, entity, relation = "part of",
-  variable_only = TRUE)
+  variable_only = TRUE, strict = TRUE)
 }
 \arguments{
 \item{taxon}{character, required. A vector of taxon names.}
@@ -21,6 +21,13 @@ Default is "part of".}
 \item{variable_only}{logical, optional.
 Whether to only include characters that are variable across the selected
 set of taxa. Default is TRUE.}
+
+\item{strict}{logical, optional. Whether or not to treat any failure to resolve
+any taxon or entity names to IRI as input error. Resolution by partial or
+other inexact match results in a warning, but is not considered a failure.
+If FALSE, query execution will continue with the taxon and entity terms
+that did resolve to IRI. Default is TRUE, meaning any resolution failure will
+result in an error.}
 }
 \value{
 \link[RNeXML:nexml]{RNeXML::nexml} object

--- a/tests/testthat/test-ontotrace.R
+++ b/tests/testthat/test-ontotrace.R
@@ -13,12 +13,12 @@ test_that("Ontotrace basics", {
                          relation = "other relation"))
   testthat::expect_warning(
     nx <- pk_get_ontotrace_xml(taxon = c("Ictalurus", "Ameiurus XXX"),
-                               entity = c("fin", "spine")))
-  # should have resulted in an empty nexml object
-  #testthat::expect_equivalent(RNeXML::summary(nx)$nblocks, c(0, 0, 0))
-  testthat::expect_warning(nx <- pk_get_ontotrace_xml("Ictalurus TT", "fin"))
-  # should have resulted in an empty nexml object
-  #testthat::expect_equivalent(RNeXML::summary(nx)$nblocks, c(0, 0, 0))
+                               entity = c("fin", "spine"),
+                               strict = FALSE))
+  sumnx <- RNeXML::summary(nx)
+  testthat::expect_equivalent(sumnx$nblocks, c(1, 1, 1))
+  testthat::expect_gt(sumnx$notus, 1)
+  testthat::expect_gt(sumnx$ncharacters, 1)
   
   single_mat <- pk_get_ontotrace(single_nex)
   multi_mat <- pk_get_ontotrace(multi_nex)


### PR DESCRIPTION
See #118 for some context. Before this change, failure to resolve any taxon name or entity name resulted in an empty matrix being returned. With this change, in strict behavior (the default) it results in an error. If non-strict behavior is selected, the query continues to be executed with those taxon and entity terms that could be resolved to IRI.

Note that resolution by partial (rather than exact) match results in a warning, but is still considered successful.

Closes #118.