### PR TITLE
Adds custom set user-agent to request headers

### DIFF
--- a/tests/testthat/test-kb.R
+++ b/tests/testthat/test-kb.R
@@ -1,5 +1,16 @@
 context("Phenoscape KB metadata etc")
 
+test_that("custom user agent is set", {
+  reflect_api <- "http://httpbin.org/user-agent"
+  ua_resp <- get_json_data(reflect_api, {})$`user-agent`
+  testthat::expect_match(ua_resp, "r-curl/[0-9.]+")
+  testthat::expect_match(ua_resp, "httr/[0-9.]+")
+  testthat::expect_match(ua_resp, paste0(utils::packageName(), "/[0-9.]+"))
+  testthat::expect_message(ua_resp2 <- get_csv_data("http://httpbin.org/user-agent", {}))
+  testthat::expect_equivalent(ua_resp, sub("\\s+user-agent:\\s+", "", ua_resp2[1,1]))
+  # unfortunately, we can't test the get_nexml_data() method in the same way
+})
+
 test_that("KB annotation summary", {
   kbmeta <- get_KBinfo()
 


### PR DESCRIPTION
This makes API calls originating through RPhenoscape idenitfiable from the web server logs. Becaude they include the version of the package (as well as versions of two key dependencies - Rcurl and httr), this will also allow monitoring how much the web services are being accessed by clients of older versions.

Also includes tests.

Implements and thus fixes #128. Thanks @sckott!