### PR TITLE
Update README badge for github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 RPhenoscape: Semantically rich phenotypic traits from the Phenoscape Knowledgebase
 ==================================================================================
 
-[![Build Status](https://travis-ci.org/phenoscape/rphenoscape.svg?branch=master)](https://travis-ci.org/phenoscape/rphenoscape)
+![Build Status](https://github.com/phenoscape/rphenoscape/workflows/R-CMD-check/badge.svg)
 
 -   Author: Hong Xu, Hilmar Lapp
 -   Maintainer: Hilmar Lapp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 RPhenoscape: Semantically rich phenotypic traits from the Phenoscape Knowledgebase
 ==================================================================================
 
-![Build Status](https://github.com/phenoscape/rphenoscape/workflows/R-CMD-check/badge.svg)
+[![Build Status](https://github.com/phenoscape/rphenoscape/workflows/R-CMD-check/badge.svg)](https://github.com/phenoscape/rphenoscape/actions)
 
 -   Author: Hong Xu, Hilmar Lapp
 -   Maintainer: Hilmar Lapp


### PR DESCRIPTION
Replaces travis-ci badge with the R-CMD-check github action badge.
Related documentation: https://docs.github.com/en/actions/managing-workflow-runs/adding-a-workflow-status-badge

Fixes #154 