### PR TITLE
Restores the earlier ProgressReporter type of test output

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
 library(rphenoscape)
 
-test_check("rphenoscape")
+test_check("rphenoscape", reporter = testthat::ProgressReporter)


### PR DESCRIPTION
This is much more useful for watching the tests unfold if the whole suite takes a while, and also gives useful information about where it consumes the most time.