### PR TITLE
Fixes expected number of exact matches

### DIFF
--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -80,7 +80,7 @@ test_that("Test retrieving IRI", {
   expect_true(is.na(iii))
 
   tiris <- find_term("pelvic fin", definedBy = NA, matchTypes = c("exact"))
-  expect_gt(nrow(tiris), 1)
+  expect_gte(nrow(tiris), 1)
   expect_silent(tiri <- pk_get_iri("pelvic fin", as = NA, exactOnly = TRUE))
   expect_equal(tiri, "http://purl.obolibrary.org/obo/UBERON_0000152")
 


### PR DESCRIPTION
The API server returns only 1 exact match anymore, not multiple. This changes to allow 1 or more being returned.

Fixes #152.