### PR TITLE
Fixes handling of term freqs that are missing or zero

### DIFF
--- a/man/similarity.Rd
+++ b/man/similarity.Rd
@@ -36,7 +36,9 @@ scores, though any score will work for which a higher value means higher
 information content, and where a term will always have a score equal to or
 greater than any of its superclasses. If a function, it must accept parameter
 \code{x} as the vector of term IRIs and return a vector of frequencies (\emph{not}
-IC scores) for the terms. The default is to use function \code{\link[=term_freqs]{term_freqs()}}.}
+IC scores) for the terms. The default is to use function \code{\link[=term_freqs]{term_freqs()}}.
+Subsumer terms with zero or missing (NA) frequency will be omitted from the
+calculation.}
 
 \item{wt_args}{list, named parameters for the function calculating term
 frequencies. Ignored if \code{wt} is not a function. For the default \code{wt}

--- a/tests/testthat/test-semsim.R
+++ b/tests/testthat/test-semsim.R
@@ -84,9 +84,9 @@ test_that("Resnik similarity", {
   termICs <- -log10(term_freqs(phens$id, as = "phenotype", corpus = "taxa"))
   testthat::expect_equivalent(diag(sm.ic), termICs)
 
-  subs.ics <- -log10(term_freqs(rownames(subs.mat),
-                                as = "phenotype", corpus = "taxa"))
-  sm.ic2 <- resnik_similarity(subs.mat, wt = subs.ics)
+  tfreqs <- term_freqs(rownames(subs.mat), as = "phenotype", corpus = "taxa")
+  sm.ic2 <- resnik_similarity(subs.mat[! (is.na(tfreqs) | tfreqs == 0), ],
+                              wt = -log10(tfreqs[! (is.na(tfreqs) | tfreqs == 0)]))
   testthat::expect_equal(sm.ic, sm.ic2)
 })
 
@@ -151,6 +151,9 @@ test_that("profile similarity with Resnik", {
   }))
 
   freqs <- term_freqs(rownames(subs.mat), as = "phenotype", corpus = "taxa")
+  toKeep <- ! (is.na(freqs) | freqs == 0)
+  freqs <- freqs[toKeep]
+  subs.mat <- subs.mat[toKeep,]
   sm <- profile_similarity(resnik_similarity, subs.mat, wt = -log10(freqs),
                            f = phens.f)
   testthat::expect_equal(colnames(sm), levels(phens.f))


### PR DESCRIPTION
The current database and API returns subsumer terms for which there is no count for certain corpora. Erroneously, the KB API currently returns a zero count for those, when it should return no count (phenoscape/phenoscape-kb-services#382). This change should handle both cases, and removes those subsumers from the calculation.

Fixes #153.