### PR TITLE
Filters out label-less terms from flagged ontologies

### DIFF
--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -128,6 +128,14 @@ test_that("labels for pre-generated post-comps", {
 
   subs <- sample(rownames(subsumer_matrix(c("femur"))), 30)
   subs.l <- get_term_label(subs, preserveOrder = TRUE)
+  # Unfortunately, there are some regular ontologies for which the database
+  # does not consistently have labels. Filter those out.
+  ontFilter <- Reduce(
+    function(v1, v2) v1 | startsWith(subs.l$id, v2),
+    paste0("http://purl.obolibrary.org/obo/", c("CARO"), "_"),
+    init = rep(FALSE, times = length(subs.l$id))
+  )
+  subs.l <- subs.l[! (is.na(subs.l$label) & ontFilter),]
   testthat::expect_lte(sum(is.na(subs.l$label)), 1)
 })
 


### PR DESCRIPTION
Some ontologies, in particular apparently CARO, have labels for terms in the database only inconsistently. This filters out subsumer terms that are in those ontologies, and failed to obtain a label. What is really being tested here are post-compositions, so this shouldn't affect the subsumers that are post-comps (whether they fail to obtain a label
or not).

Fixes #161. See also phenoscape/phenoscape-kb-services#378.