### PR TITLE
Updates github action tests to run every Thursday

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -6,6 +6,8 @@ on:
       - main
       - master
   pull_request:
+  schedule:
+    - cron:  '0 23 * * THU'
 
 name: R-CMD-check
 


### PR DESCRIPTION
Adds the `schedule` block to the `check-standard` github action config.
Tests will be run every Thursday at 23:00 UTC.
The `schedule` config only applies to the default branch.

Fixes #164 
