### PR TITLE
Removes hard coded phenoscape api URLs

### DIFF
--- a/R/pk_get_IRI.R
+++ b/R/pk_get_IRI.R
@@ -70,8 +70,7 @@ find_term <- function(query,
   if (is.na(limit)) limit <- "1000000"
   queryseq <- c(queryseq, limit = limit)
 
-  res <- pk_GET(pkb_api("/term/search"), query = queryseq)
-
+  res <- get_json_data(pkb_api("/term/search"), query = queryseq)
   res <- res$results
 
   if (length(res) > 0 && nrow(res) > 0) {

--- a/R/pk_get_IRI.R
+++ b/R/pk_get_IRI.R
@@ -70,7 +70,8 @@ find_term <- function(query,
   if (is.na(limit)) limit <- "1000000"
   queryseq <- c(queryseq, limit = limit)
 
-  res <- pk_GET('http://kb.phenoscape.org/api/term/search', query = queryseq)
+  res <- pk_GET(pkb_api("/term/search"), query = queryseq)
+
   res <- res$results
 
   if (length(res) > 0 && nrow(res) > 0) {

--- a/R/pk_get_xml.R
+++ b/R/pk_get_xml.R
@@ -107,7 +107,7 @@ pk_get_ontotrace_xml <- function(taxon, entity,
                   entity = paste(entity_iris, collapse = " or "),
                   variable_only = variable_only)
 
-  nex <- get_nexml_data(ontotrace_url, queryseq)
+  nex <- get_nexml_data(pkb_api("/ontotrace"), queryseq)
   return(nex)
 }
 
@@ -129,7 +129,7 @@ pk_get_study_xml <- function(study_ids) {
   for (s in study_ids) {
     message(s)
     queryseq <- list(iri = s)
-    nex <- get_nexml_data(pk_study_matrix_url, queryseq)
+    nex <- get_nexml_data(pkb_api("/study/matrix"), queryseq)
     ret[[s]] <- nex
   }
 
@@ -137,8 +137,6 @@ pk_get_study_xml <- function(study_ids) {
 }
 
 
-ontotrace_url <- "https://kb.phenoscape.org/api/ontotrace"
 quantifier <- " some " # seperate quantifier
 part_relation <- "<http://purl.obolibrary.org/obo/BFO_0000050>" # "part of"
 develops_relation <- "<http://purl.obolibrary.org/obo/RO_0002202>" # "develops from"
-pk_study_matrix_url <- "http://kb.phenoscape.org/api/study/matrix"

--- a/R/pk_is_descendant.R
+++ b/R/pk_is_descendant.R
@@ -72,9 +72,9 @@ pk_is <- function(term, candidates,
   }
 
   if (mode == 'ancestor')
-    apiURL <- pk_ancestor_url
+    apiURL <- pkb_api("/term/all_ancestors")
   else
-    apiURL <- pk_descendant_url
+    apiURL <- pkb_api("/term/all_descendants")
   res <- pk_GET(apiURL, queryseq)
   res <- res$results
 
@@ -83,7 +83,3 @@ pk_is <- function(term, candidates,
   else
     term_iris[-1] %in% res$`@id`
 }
-
-pk_subsumer_url <- "http://kb.phenoscape.org/api/term/least_common_subsumers"
-pk_ancestor_url <- "http://kb.phenoscape.org/api/term/all_ancestors"
-pk_descendant_url <- "http://kb.phenoscape.org/api/term/all_descendants"

--- a/R/pk_is_descendant.R
+++ b/R/pk_is_descendant.R
@@ -75,7 +75,7 @@ pk_is <- function(term, candidates,
     apiURL <- pkb_api("/term/all_ancestors")
   else
     apiURL <- pkb_api("/term/all_descendants")
-  res <- pk_GET(apiURL, queryseq)
+  res <- get_json_data(apiURL, queryseq)
   res <- res$results
 
   if (length(res) == 0)

--- a/R/pk_terms.R
+++ b/R/pk_terms.R
@@ -118,7 +118,7 @@ pk_details <- function(term, as, verbose=FALSE) {
   mssg(verbose, "Retrieving term details")
 
   queryseq <- list(iri = iri)
-  lst <- pk_GET("http://kb.phenoscape.org/api/term", queryseq)
+  lst <- pk_GET(pkb_api("/term"), queryseq)
   names(lst) <- sub("@", "", names(lst))
   as.data.frame(Filter(function(x) !is.list(x), lst))
 }
@@ -170,7 +170,3 @@ get_term_label <- function(term_iris, preserveOrder = FALSE, verbose = FALSE) {
 
   res
 }
-
-pk_taxon_url <- "http://kb.phenoscape.org/api/taxon"
-
-

--- a/R/pk_terms.R
+++ b/R/pk_terms.R
@@ -118,7 +118,7 @@ pk_details <- function(term, as, verbose=FALSE) {
   mssg(verbose, "Retrieving term details")
 
   queryseq <- list(iri = iri)
-  lst <- pk_GET(pkb_api("/term"), queryseq)
+  lst <- get_json_data(pkb_api("/term"), queryseq)
   names(lst) <- sub("@", "", names(lst))
   as.data.frame(Filter(function(x) !is.list(x), lst))
 }

--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -80,7 +80,6 @@ get_json_data <- function(url, query,
   }
   res
 }
-pk_GET <- get_json_data
 
 
 #' Clean JSON-LD names in a list/data.frame


### PR DESCRIPTION
Uses pkb_api() instead of hard coded strings for phenoscape API URLs.
Fixes #166

Replaces pk_GET() function calls with get_json_data() and removes pk_GET declaration.
Fixes #167 