### PR TITLE
Runs tests against phenoscape dev server

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -73,6 +73,14 @@ jobs:
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
         shell: Rscript {0}
 
+      - name: Check tests against dev server
+        if: github.event_name == 'schedule' # only run this step when called by cron
+        env:
+          _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          PHENOSCAPE_API: https://stars-app.renci.org/phenoscape-dev-api
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
+        shell: Rscript {0}
+
       - name: Upload check results
         if: failure()
         uses: actions/upload-artifact@main

--- a/R/pk_classification.R
+++ b/R/pk_classification.R
@@ -31,10 +31,8 @@ pk_class <- function(x, as, verbose=TRUE) {
   mssg(verbose, "Retrieving classification information")
 
   queryseq <- list(iri = iri)
-  pk_GET(pk_class_url, query = queryseq)
+  pk_GET(pkb_api("/term/classification"), query = queryseq)
 }
-pk_class_url <- "http://kb.phenoscape.org/api/term/classification"
-
 
 
 

--- a/R/pk_get_IRI.R
+++ b/R/pk_get_IRI.R
@@ -70,7 +70,8 @@ find_term <- function(query,
   if (is.na(limit)) limit <- "1000000"
   queryseq <- c(queryseq, limit = limit)
 
-  res <- pk_GET('http://kb.phenoscape.org/api/term/search', query = queryseq)
+  res <- pk_GET(pkb_api("/term/search"), query = queryseq)
+
   res <- res$results
 
   if (length(res) > 0 && nrow(res) > 0) {

--- a/R/pk_get_xml.R
+++ b/R/pk_get_xml.R
@@ -107,7 +107,7 @@ pk_get_ontotrace_xml <- function(taxon, entity,
                   entity = paste(entity_iris, collapse = " or "),
                   variable_only = variable_only)
 
-  nex <- get_nexml_data(ontotrace_url, queryseq)
+  nex <- get_nexml_data(pkb_api("/ontotrace"), queryseq)
   return(nex)
 }
 
@@ -129,7 +129,7 @@ pk_get_study_xml <- function(study_ids) {
   for (s in study_ids) {
     message(s)
     queryseq <- list(iri = s)
-    nex <- get_nexml_data(pk_study_matrix_url, queryseq)
+    nex <- get_nexml_data(pkb_api("/study/matrix"), queryseq)
     ret[[s]] <- nex
   }
 
@@ -137,8 +137,6 @@ pk_get_study_xml <- function(study_ids) {
 }
 
 
-ontotrace_url <- "https://kb.phenoscape.org/api/ontotrace"
 quantifier <- " some " # seperate quantifier
 part_relation <- "<http://purl.obolibrary.org/obo/BFO_0000050>" # "part of"
 develops_relation <- "<http://purl.obolibrary.org/obo/RO_0002202>" # "develops from"
-pk_study_matrix_url <- "http://kb.phenoscape.org/api/study/matrix"

--- a/R/pk_is_descendant.R
+++ b/R/pk_is_descendant.R
@@ -72,9 +72,9 @@ pk_is <- function(term, candidates,
   }
 
   if (mode == 'ancestor')
-    apiURL <- pk_ancestor_url
+    apiURL <- pkb_api("/term/all_ancestors")
   else
-    apiURL <- pk_descendant_url
+    apiURL <- pkb_api("/term/all_descendants")
   res <- pk_GET(apiURL, queryseq)
   res <- res$results
 
@@ -83,7 +83,3 @@ pk_is <- function(term, candidates,
   else
     term_iris[-1] %in% res$`@id`
 }
-
-pk_subsumer_url <- "http://kb.phenoscape.org/api/term/least_common_subsumers"
-pk_ancestor_url <- "http://kb.phenoscape.org/api/term/all_ancestors"
-pk_descendant_url <- "http://kb.phenoscape.org/api/term/all_descendants"

--- a/R/pk_study.R
+++ b/R/pk_study.R
@@ -108,7 +108,7 @@ pk_get_study_list <- function(taxon = NA, entity = NA, quality = NA,
 
   if (! is.na(phenotype)) queryseq <- c(queryseq, phenotype = phenotype)
 
-  out <- pk_GET(pk_study_url, queryseq)
+  out <- pk_GET(pkb_api("/study/query"), queryseq)
   d <- out$results
 
   if (length(d) == 0) {
@@ -238,5 +238,3 @@ unique_label <- function(m) {
   c <- grepl('character', cname)
   return(!c)
 }
-
-pk_study_url <- "http://kb.phenoscape.org/api/study/query"

--- a/R/pk_terms.R
+++ b/R/pk_terms.R
@@ -118,7 +118,7 @@ pk_details <- function(term, as, verbose=FALSE) {
   mssg(verbose, "Retrieving term details")
 
   queryseq <- list(iri = iri)
-  lst <- pk_GET("http://kb.phenoscape.org/api/term", queryseq)
+  lst <- pk_GET(pkb_api("/term"), queryseq)
   names(lst) <- sub("@", "", names(lst))
   as.data.frame(Filter(function(x) !is.list(x), lst))
 }
@@ -170,7 +170,3 @@ get_term_label <- function(term_iris, preserveOrder = FALSE, verbose = FALSE) {
 
   res
 }
-
-pk_taxon_url <- "http://kb.phenoscape.org/api/taxon"
-
-

--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -120,7 +120,7 @@ get_nexml_data <- function(url, query, verbose = FALSE, forceGET = FALSE) {
 pkb_api <- function(...) {
   path <- paste(..., sep = "/")
   if (! startsWith(path, "/")) path <- paste0("/", path)
-  paste0("https://kb.phenoscape.org/api", path)
+  paste0(phenoscape_api, path)
 }
 
 #' Creates a list of named query parameters
@@ -211,3 +211,5 @@ ua <- local({
     .ua
   }
 })
+
+phenoscape_api <- Sys.getenv("PHENOSCAPE_API", "https://kb.phenoscape.org/api")


### PR DESCRIPTION
Changes rphenoscape to allow overriding the kb.phenoscape API URL by setting the __PHENOSCAPE_API__ environment variable. Part of this change was replacing hard coded kb.phenoscape URLs with the `pkb_api()` function. 

Updates github actions to test the dev kb.phenoscape API when run from cron. The production API will continue to be tested when run from cron. For push and PRs the github actions will only test against the production API.

Fixes #181
