### PR TITLE
Fixes use of environment for KB API endpoint

### DIFF
--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -120,7 +120,7 @@ get_nexml_data <- function(url, query, verbose = FALSE, forceGET = FALSE) {
 pkb_api <- function(...) {
   path <- paste(..., sep = "/")
   if (! startsWith(path, "/")) path <- paste0("/", path)
-  paste0(phenoscape_api, path)
+  paste0(phenoscape_api(), path)
 }
 
 #' Creates a list of named query parameters
@@ -212,4 +212,12 @@ ua <- local({
   }
 })
 
-phenoscape_api <- Sys.getenv("PHENOSCAPE_API", "https://kb.phenoscape.org/api")
+phenoscape_api <- local({
+  .api <- NA;
+  function() {
+    if (is.na(.api)) {
+      .api <<- Sys.getenv("PHENOSCAPE_API", "https://kb.phenoscape.org/api")
+    }
+    .api
+  }
+})


### PR DESCRIPTION
"Static" instructions (those at the level of files, not within functions) get executed once, at package installation time, and not as one might hope every time the library is loaded. Hence, using a static instruction for setting the API endpoint URL from an environment variable will work in automatic testing, because that starts with freshly installing the library while the desired environment setting is already in effect. To allow having this work in a local dev environment, it needs to be determined
dynamically.

I am using a `local()` function environment here to cache the value for an R session (for which it can be set through, for example, .Renviron). Another possibility would be a substitute()/eval() combination, which wouldn't cache anything though.