### PR TITLE
Fix github status badge

### DIFF
--- a/.github/workflows/kb-beta-API-check.yaml
+++ b/.github/workflows/kb-beta-API-check.yaml
@@ -4,10 +4,10 @@ on:
   schedule:
     - cron:  '0 23 * * THU'
 
-name: kb-dev-API-check
+name: kb-beta-API-check
 
 jobs:
-  kb-dev-API-check:
+  kb-beta-API-check:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -62,10 +62,10 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Check tests against kb.phenoscape API dev server
+      - name: Check tests against kb.phenoscape API v2-beta server
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
-          PHENOSCAPE_API: https://stars-app.renci.org/phenoscape-dev-api
+          PHENOSCAPE_API: https://dev.phenoscape.org/api/v2-beta
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
         shell: Rscript {0}
 

--- a/.github/workflows/kb-dev-API-check.yaml
+++ b/.github/workflows/kb-dev-API-check.yaml
@@ -1,16 +1,13 @@
 # For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on:
-  push:
-    branches:
-      - main
-      - master
-  pull_request:
+  schedule:
+    - cron:  '0 23 * * THU'
 
-name: R-CMD-check
+name: kb-dev-API-check
 
 jobs:
-  R-CMD-check:
+  kb-dev-API-check:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -65,9 +62,10 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
-      - name: Check
+      - name: Check tests against kb.phenoscape API dev server
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          PHENOSCAPE_API: https://stars-app.renci.org/phenoscape-dev-api
         run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "error", check_dir = "check")
         shell: Rscript {0}
 


### PR DESCRIPTION
Moves test of the development kb.phenoscape API out of the `R-CMD-check` github action workflow which is used to build a badge for the README. Since the REAMDE badge is already based on `R-CMD-check` I don't think any changes are required there.

Upgrades weekly test to use the new v2-beta API.


Fixes #205