### PR TITLE
Fixes v2-beta API terminfo test

### DIFF
--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -262,7 +262,7 @@ phenoscape_api <- local({
   .api <- NA;
   function() {
     if (is.na(.api)) {
-      .api <<- Sys.getenv("PHENOSCAPE_API", "https://kb.phenoscape.org/api")
+      .api <<- Sys.getenv("PHENOSCAPE_API", "https://dev.phenoscape.org/api/v2-beta")
     }
     .api
   }

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -320,6 +320,9 @@ test_that("creating terminfo objects and extracting properties", {
   testthat::expect_true(all(is_valid_terminfo(objs)))
   l <- sapply(objs, function(p) p$label)
   testthat::expect_true(all(l == terms$label))
+  # filter out ZP terms because they do not have synonyms
+  non_zp_terms <- terms[terms$isDefinedBy != ontology_iri("ZP"),]
+  objs <- as.terminfo(non_zp_terms$id)
   testthat::expect_true(all(sapply(objs, function(p) nrow(p$synonyms)) > 0))
 })
 


### PR DESCRIPTION
Switches to the phenoscape kb v2-beta API as part of #209.
Fixes v2-beta bug in terminfo test by filtering out ZP terms that do not have synonyms.

Fixes #210 
