### PR TITLE
Fixes v2-beta entity subsumer test

### DIFF
--- a/tests/testthat/test-freqs.R
+++ b/tests/testthat/test-freqs.R
@@ -61,7 +61,11 @@ test_that("success rate for entity subsumer terms", {
   tt <- sapply(c("fin ray", "dorsal fin", "caudal fin"), get_term_iri, as = "anatomy")
   subs.mat <- subsumer_matrix(tt)
   tt.types <- term_category(rownames(subs.mat))
-  type.fracs <- table(tt.types)/nrow(subs.mat)
+  # less than 10% of the terms should be indeterminate
+  testthat::expect_lt(mean(is.na(tt.types)), .1)
+  # remove NA types
+  tt.types <- tt.types[!is.na(tt.types)]
+  type.fracs <- table(tt.types)/length(tt.types)
   testthat::expect_lte(length(names(type.fracs)), 3)
   testthat::expect_gt(max(type.fracs), 0.9)
   testthat::expect_equal(names(type.fracs)[type.fracs == max(type.fracs)], "entity")


### PR DESCRIPTION
The category of some terms is no longer determinate as of
v2-beta so term_category now returns NA in this case.
Updates the test to account for this by filtering NA.

Fixes #212