### PR TITLE
Removes term_freqs taxon_annotations corpus

### DIFF
--- a/R/term-weights.R
+++ b/R/term-weights.R
@@ -6,12 +6,7 @@
 #' Depending on the corpus selected, the frequencies are queried directly
 #' from pre-computed counts through the KB API, or are calculated based on
 #' matching row counts obtained from query results. Currently, the Phenoscape KB
-#' has precomputed counts for corpora "taxa" and "genes". Calculated counts for
-#' the "taxon_annotations" corpus are most reliable for phenotype terms and their
-#' subsumers. For entity terms, subsumers can include many generated
-#' post-composed terms (such as "part_of some X", where X is, for example, an
-#' anatomy term), and at least currently these aren't handled correctly by the
-#' Phenoscape KB, resulting in counts of zero for such terms.
+#' has precomputed counts for corpora "taxa" and "genes".
 #' @note
 #' Term categories being accurate is vital for obtaining correct counts and
 #' thus frequencies. In earlier (<=0.2.x) releases, auto-determining term
@@ -21,16 +16,23 @@
 #' KB v2.0 API, auto-determining the category of a post-composed term is no
 #' longer supported. If the list of terms is legitimately of different categories,
 #' determine (and possibly correct) categories beforehand using [term_category()].
+#' In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, but
+#' this is no longer the case due to the inability to determine an accurate
+#' count for post-composed terms with the KB v2.0 API. This also means that the
+#' only supported value for the `as` parameter is "phenotype" since "entity" and
+#' "quality" were only supported for the "taxon_annotations" corpus.
 #' @param x a vector or list of one or more terms, either as IRIs or as term
 #'   objects.
 #' @param as the category or categories of the input terms (see [term_category()]).
-#'   Supported categories are "entity", "quality", and "phenotype". The value
-#'   must either be a single category (applying to all terms), or a vector of
-#'   categories (of same length as `x`). The default is "entity".
+#'   Supported categories are "entity", "quality", and "phenotype". (At present,
+#'   support for "entity" and "quality" has been disabled as of v0.3.0, pending full support from the KB API.)
+#'   The value must either be a single category (applying to all terms), or a vector of
+#'   categories (of same length as `x`). The default is "phenotype".
 #' @param corpus the name of the corpus for which to determine frequencies.
 #'   Supported values are "taxon_annotations", "taxa", "gene_annotations", and
-#'   "genes". (At present, support for "gene_annotations" is pending support in
-#'   the Phenoscape API.) The default is "taxon_annotations".
+#'   "genes". (At present, support for "gene_annotations" and "taxon_annotations" is disabled, pending support in
+#'   the Phenoscape KB API.)
+#'   The default is "taxa".
 #' @param decodeIRI boolean. This parameter is deprecated (as of v0.3.x) and must be set
 #'  to FALSE (the default). If TRUE is passed an error will be raised. In v0.2.x
 #'  when TRUE this parameter would attempt to decode post-composed entity IRIs.
@@ -45,18 +47,13 @@
 #' @return a vector of frequencies as floating point numbers (between zero
 #'   and 1.0), of the same length (and ordering) as the input list of terms.
 #' @examples
-#' terms <- c("pectoral fin", "pelvic fin", "dorsal fin", "paired fin")
-#' IRIs <- sapply(terms, get_term_iri, as = "anatomy")
-#' term_freqs(IRIs, as = "entity")
-#' 
 #' phens <- get_phenotypes(entity = "basihyal bone")
-#' term_freqs(phens$id, as = "phenotype", corpus = "taxon_annotations")
 #' term_freqs(phens$id, as = "phenotype", corpus = "taxa")
-#' 
+#' term_freqs(phens$id, as = "phenotype", corpus = "genes")
 #' @export
 term_freqs <- function(x,
-                       as = c("entity", "quality", "phenotype"),
-                       corpus = c("taxon_annotations", "taxa", "gene_annotations", "genes"),
+                       as = c("phenotype", "entity", "quality"),
+                       corpus = c("taxa", "taxon_annotations", "gene_annotations", "genes"),
                        decodeIRI = FALSE,
                        ...) {
   as <- match.arg(as, several.ok = TRUE)
@@ -76,32 +73,10 @@ term_freqs <- function(x,
                           header = FALSE, row.names = 1, check.names = FALSE)
     reordering <- match(x, rownames(freqs))
     freqs <- freqs[reordering,] / ctotal
-  } else if (corpus == "taxon_annotations") {
-    freqs <- mapply(annotations_count,
-                    iri = x, termType = as, ...)
-    freqs <- freqs / ctotal
   } else {
     stop("corpus '", corpus, "' is currently unsupported", call. = FALSE)
   }
   unname(freqs)
-}
-
-annotations_count <- function(iri, termType,
-                              apiEndpoint = "/taxon/annotations",
-                              ...) {
-  query <- pkb_args_to_query(...)
-  query$total <- TRUE
-  if (is.null(query[[termType]])) query[[termType]] <- iri
-  res <- get_json_data(pkb_api(apiEndpoint), query = query)
-  # if the IRI used for counting is a result of decoding the IRI, _and_ if
-  # we haven't included parts in the count already
-  if ((query[[termType]] != iri) && (is.null(query$parts) || ! query$parts)) {
-    # count with including parts, then subtract entities alone (counted before)
-    query$parts <- TRUE
-    res2 <- get_json_data(pkb_api(apiEndpoint), query = query)
-    res2$total - res$total
-  } else
-    res$total
 }
 
 #' Obtain the size of different corpora

--- a/man/term_freqs.Rd
+++ b/man/term_freqs.Rd
@@ -6,8 +6,8 @@
 \usage{
 term_freqs(
   x,
-  as = c("entity", "quality", "phenotype"),
-  corpus = c("taxon_annotations", "taxa", "gene_annotations", "genes"),
+  as = c("phenotype", "entity", "quality"),
+  corpus = c("taxa", "taxon_annotations", "gene_annotations", "genes"),
   decodeIRI = FALSE,
   ...
 )
@@ -17,14 +17,16 @@ term_freqs(
 objects.}
 
 \item{as}{the category or categories of the input terms (see \code{\link[=term_category]{term_category()}}).
-Supported categories are "entity", "quality", and "phenotype". The value
-must either be a single category (applying to all terms), or a vector of
-categories (of same length as \code{x}). The default is "entity".}
+Supported categories are "entity", "quality", and "phenotype". (At present,
+support for "entity" and "quality" has been disabled as of v0.3.0, pending full support from the KB API.)
+The value must either be a single category (applying to all terms), or a vector of
+categories (of same length as \code{x}). The default is "phenotype".}
 
 \item{corpus}{the name of the corpus for which to determine frequencies.
 Supported values are "taxon_annotations", "taxa", "gene_annotations", and
-"genes". (At present, support for "gene_annotations" is pending support in
-the Phenoscape API.) The default is "taxon_annotations".}
+"genes". (At present, support for "gene_annotations" and "taxon_annotations" is disabled, pending support in
+the Phenoscape KB API.)
+The default is "taxa".}
 
 \item{decodeIRI}{boolean. This parameter is deprecated (as of v0.3.x) and must be set
 to FALSE (the default). If TRUE is passed an error will be raised. In v0.2.x
@@ -51,12 +53,7 @@ the selected corpus.
 Depending on the corpus selected, the frequencies are queried directly
 from pre-computed counts through the KB API, or are calculated based on
 matching row counts obtained from query results. Currently, the Phenoscape KB
-has precomputed counts for corpora "taxa" and "genes". Calculated counts for
-the "taxon_annotations" corpus are most reliable for phenotype terms and their
-subsumers. For entity terms, subsumers can include many generated
-post-composed terms (such as "part_of some X", where X is, for example, an
-anatomy term), and at least currently these aren't handled correctly by the
-Phenoscape KB, resulting in counts of zero for such terms.
+has precomputed counts for corpora "taxa" and "genes".
 }
 \note{
 Term categories being accurate is vital for obtaining correct counts and
@@ -67,14 +64,14 @@ the many post-composed subsumer terms returned by \code{\link[=subsumer_matrix]{
 KB v2.0 API, auto-determining the category of a post-composed term is no
 longer supported. If the list of terms is legitimately of different categories,
 determine (and possibly correct) categories beforehand using \code{\link[=term_category]{term_category()}}.
+In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, but
+this is no longer the case due to the inability to determine an accurate
+count for post-composed terms with the KB v2.0 API. This also means that the
+only supported value for the \code{as} parameter is "phenotype" since "entity" and
+"quality" were only supported for the "taxon_annotations" corpus.
 }
 \examples{
-terms <- c("pectoral fin", "pelvic fin", "dorsal fin", "paired fin")
-IRIs <- sapply(terms, get_term_iri, as = "anatomy")
-term_freqs(IRIs, as = "entity")
-
 phens <- get_phenotypes(entity = "basihyal bone")
-term_freqs(phens$id, as = "phenotype", corpus = "taxon_annotations")
 term_freqs(phens$id, as = "phenotype", corpus = "taxa")
-
+term_freqs(phens$id, as = "phenotype", corpus = "genes")
 }

--- a/tests/testthat/test-freqs.R
+++ b/tests/testthat/test-freqs.R
@@ -91,33 +91,16 @@ test_that("obtaining corpus size", {
 })
 
 test_that("obtaining/calculating term frequencies", {
-  tl <- c("pelvic fin", "pectoral fin", "forelimb", "hindlimb", "dorsal fin", "caudal fin")
-  tt <- sapply(tl, get_term_iri, as = "anatomy", exactOnly = TRUE)
-
-  wt <- term_freqs(tt, as = "entity", corpus = "taxon_annotations")
+  phens <- get_phenotypes(entity = "pectoral fin", quality = "present")
+  wt <- term_freqs(phens$id, as = "phenotype")
   testthat::expect_is(wt, "numeric")
-  testthat::expect_length(wt, length(tt))
+  testthat::expect_length(wt, length(phens$id))
   testthat::expect_true(all(wt >= 0))
   testthat::expect_true(all(wt <= 1))
 
-  wt1 <- term_freqs(tt, as = "entity")
-  testthat::expect_identical(wt1, wt)
-  wt1 <- term_freqs(tt, as = c(rep("entity", times = 5), "quality"))
-  testthat::expect_false(all(wt1 == wt))
-  testthat::expect_true(all(wt1[1:5] == wt[1:5]))
-  testthat::expect_equal(wt1[6], 0)
-
-  phens <- get_phenotypes(entity = "pelvic fin", quality = "shape")
-  wt <- term_freqs(phens$id, as = "phenotype", corpus = "taxon_annotations")
-  testthat::expect_length(wt, nrow(phens))
-  testthat::expect_true(all(wt >= 0))
-  testthat::expect_true(all(wt <= 1))
+  # check that the corpus defaults to "taxa"
   wt1 <- term_freqs(phens$id, as = "phenotype", corpus = "taxa")
-  testthat::expect_length(wt1, nrow(phens))
-  testthat::expect_true(all(wt1 >= 0))
-  testthat::expect_true(all(wt1 <= 1))
-  # expect 80%+ of the taxa freqs to be > than the taxon annotations freqs
-  testthat::expect_gt(mean(wt < wt1), .8)
+  testthat::expect_identical(wt1, wt)
 
   # checking of error conditions
   testthat::expect_error(term_freqs(phens$id, as = "foobar"))
@@ -127,6 +110,7 @@ test_that("obtaining/calculating term frequencies", {
                                                          times = nrow(phens)-1),
                                                      "auto")))
   testthat::expect_error(term_freqs(phens$id, as = "entity", corpus = "taxa"))
+  testthat::expect_error(term_freqs(phens$id, as = "quality", corpus = "taxa"))
 })
 
 test_that("term frequencies for post-comp subsumers of entities", {
@@ -135,8 +119,8 @@ test_that("term frequencies for post-comp subsumers of entities", {
   # reduce to post-comps and test a handful
   onts <- obo_prefix(subs)
   subs <- subs[is.na(onts)]
-  if (length(subs) > 5) subs <- subs[1:5]
-  freqs <- term_freqs(subs, as = "entity", corpus = "taxon_annotations")
-  testthat::expect_true(any(freqs > 0))
+  # Expect an error since the taxon_annotations corpus is no longer supported.
+  testthat::expect_error(term_freqs(subs, as = "entity", corpus = "taxon_annotations"), 
+                         "corpus 'taxon_annotations' is currently unsupported")
 })
 

--- a/tests/testthat/test-semsim.R
+++ b/tests/testthat/test-semsim.R
@@ -69,25 +69,12 @@ test_that("Resnik similarity", {
   subs.mat1 <- subs.mat[s,]
   rownames(subs.mat1) <- subs1
   sm.ic <- resnik_similarity(subs.mat1,
-                             wt_args = list(as = "phenotype", corpus = "taxon_annotations"))
-  testthat::expect_equal(dim(sm.ic), c(nrow(phens), nrow(phens)))
-  testthat::expect_true(all(sm.ic > 0))
-  testthat::expect_true(all(sm.ic <= -log10(1 / corpus_size("taxon_annotations"))))
-  termICs <- -log10(term_freqs(phens$id, as = "phenotype", corpus = "taxon_annotations"))
-  testthat::expect_equivalent(diag(sm.ic), termICs)
-
-  sm.ic <- resnik_similarity(subs.mat,
                              wt_args = list(as = "phenotype", corpus = "taxa"))
   testthat::expect_equal(dim(sm.ic), c(nrow(phens), nrow(phens)))
   testthat::expect_true(all(sm.ic > 0))
   testthat::expect_true(all(sm.ic <= -log10(1 / corpus_size("taxa"))))
   termICs <- -log10(term_freqs(phens$id, as = "phenotype", corpus = "taxa"))
   testthat::expect_equivalent(diag(sm.ic), termICs)
-
-  tfreqs <- term_freqs(rownames(subs.mat), as = "phenotype", corpus = "taxa")
-  sm.ic2 <- resnik_similarity(subs.mat[! (is.na(tfreqs) | tfreqs == 0), ],
-                              wt = -log10(tfreqs[! (is.na(tfreqs) | tfreqs == 0)]))
-  testthat::expect_equal(sm.ic, sm.ic2)
 })
 
 test_that("profile similarity with Jaccard", {


### PR DESCRIPTION
Removes the ability to use `corpus = "taxon_annotations"` with `term_freqs()`.
This means the only `corpus` supported are "taxa" and "genes".
The `as` parameter is also restricted to "phenotype" now, because this is the only value supported by "taxa" and "genes".

Fixes #214