### PR TITLE
Removes KB API limit work around

### DIFF
--- a/R/get_IRI.R
+++ b/R/get_IRI.R
@@ -67,7 +67,7 @@ find_term <- function(query,
   }
   
   # apply limit to result
-  if (is.na(limit)) limit <- "1000000"
+  if (is.na(limit)) limit <- "0"
   queryseq <- c(queryseq, limit = limit)
 
   res <- get_json_data(pkb_api("/term/search"), query = queryseq)

--- a/R/phenotypes.R
+++ b/R/phenotypes.R
@@ -82,7 +82,7 @@ get_phenotypes <- function(entity = NA, quality = NA, taxon = NA, study = NA,
   # note that evaluation needs to be in this function's parent frame, or
   # otherwise using it in apply() and friends won't work
   queryseq <- do.call(pkb_args_to_query, argsInCall, envir = parent.frame())
-  queryseq <- c(queryseq, limit = "1000000")
+  queryseq <- c(queryseq, limit = "0")
 
   mssg(verbose, "Querying for phenotypes ...")
   if (is.na(taxon) || ! .withTaxon)

--- a/R/pk_study.R
+++ b/R/pk_study.R
@@ -71,7 +71,7 @@ get_studies <- function(taxon = NA, entity = NA, quality = NA,
   # note that evaluation needs to be in this function's parent frame, or
   # otherwise using it in apply() and friends won't work
   queryseq <- do.call(pkb_args_to_query, argsInCall, envir = parent.frame())
-  queryseq <- c(queryseq, limit = "1000000")
+  queryseq <- c(queryseq, limit = "0")
   if (! is.na(phenotype)) queryseq <- c(queryseq, phenotype = phenotype)
 
   out <- get_json_data(pkb_api("/study/query"), queryseq)

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -127,6 +127,11 @@ test_that("Test retrieving IRI", {
   expect_true(startsWith(tiri, "http://purl.obolibrary.org/obo/"))
 })
 
+test_that("Test finding terms without a limit", {
+  # Ensure that we receive more than the default KB API limit (100)
+  expect_gt(nrow(find_term("fin", limit=NA)), 100)
+})
+
 test_that("Deprecated function forr retrieving IRI", {
   skip_on_cran()
 

--- a/tests/testthat/test-study.R
+++ b/tests/testthat/test-study.R
@@ -94,6 +94,11 @@ test_that("Test getting study information", {
   
 })
 
+test_that("Test finding studies fetches more than the default KB limit", {
+  # Ensure that we receive more than the default KB API limit (20)
+  expect_gt(nrow(get_studies(entity = "pelvic fin")), 20)
+})
+
 test_that("Test deprecated get study data", {
   skip_on_cran()
   # backwards compatible mode, defaults to including part_of


### PR DESCRIPTION
Previously the KB API had no mechanism to limit some queries so
instead we used really large magic numbers. The change here is
to use 0 for limit that is now supported by the KB API.

Fixes #183