### PR TITLE
Update baseline-v0.3.0 URL

### DIFF
--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -262,7 +262,7 @@ phenoscape_api <- local({
   .api <- NA;
   function() {
     if (is.na(.api)) {
-      .api <<- Sys.getenv("PHENOSCAPE_API", "https://dev.phenoscape.org/api/v2-beta")
+      .api <<- Sys.getenv("PHENOSCAPE_API", "https://kb.phenoscape.org/api/v2-beta")
     }
     .api
   }


### PR DESCRIPTION
Updates phenoscape KB API URL to https://kb.phenoscape.org/api/v2-beta/
Fixes #241