### PR TITLE
Support new KB API corpus changesCorpus KB API changes

### DIFF
--- a/R/get_IRI.R
+++ b/R/get_IRI.R
@@ -227,8 +227,14 @@ anatomy_ontology_iris <- local({
                        matchBy = c("rdfs:label"),
                        matchTypes = c("exact", "partial"),
                        limit = 200)
+      # Include terms with labels begin with "anatomical structure"
+      # Exclude terms with labels containing "quality" or "abnormal" to remove PATO and ZP
       res <- dplyr::filter_at(res, "label",
-                              all_vars(startsWith(., "anatomical structure")))
+                              all_vars(
+                                startsWith(., "anatomical structure")
+                                & !grepl("quality", .)
+                                & !grepl("abnormal", .)
+                             ))
       .iris <<- unique(res$isDefinedBy)
     }
     .iris

--- a/R/pkb_get.R
+++ b/R/pkb_get.R
@@ -262,7 +262,7 @@ phenoscape_api <- local({
   .api <- NA;
   function() {
     if (is.na(.api)) {
-      .api <<- Sys.getenv("PHENOSCAPE_API", "https://kb.phenoscape.org/api/v2-beta")
+      .api <<- Sys.getenv("PHENOSCAPE_API", "https://dev.phenoscape.org/api/v2-beta")
     }
     .api
   }

--- a/R/term-weights.R
+++ b/R/term-weights.R
@@ -61,13 +61,14 @@ term_freqs <- function(x,
   if (decodeIRI) stop("Decoding an IRI is no longer supported.")
   if (length(as) > 1 && length(as) != length(x))
     stop("'as' must be a single value, or have the same length as 'x'", call. = FALSE)
-
+  if (length(unique(as)) != 1)
+    stop("'as' currently requires all values to be the same", call. = FALSE)
   if (corpus == "taxa" || corpus == "genes" || corpus == "states") {
-    if (any(as != "phenotype"))
-      stop("corpus '", corpus, "' requires phenotype terms", call. = FALSE)
     ctotal <- corpus_size(corpus = corpus)
     corpusID <- paste0("http://kb.phenoscape.org/sim/", corpus)
-    ontology_terms_type <- as
+    # for now 'as' must contain the same value so use the first one since
+    # /similarity/frequency type field only allows one value
+    ontology_terms_type <- as[1]
     if (ontology_terms_type == "entity") {
       ontology_terms_type <- "anatomical_entity"
     }

--- a/R/term-weights.R
+++ b/R/term-weights.R
@@ -1,7 +1,7 @@
 #' Obtains term frequencies for the Phenoscape KB
 #'
 #' Determines the frequencies for the given input list of terms, based on
-#' the selected corpus.
+#' the selected corpus and the type of the terms.
 #'
 #' Depending on the corpus selected, the frequencies are queried directly
 #' from pre-computed counts through the KB API, or are calculated based on
@@ -11,28 +11,39 @@
 #' Term categories being accurate is vital for obtaining correct counts and
 #' thus frequencies. In earlier (<=0.2.x) releases, auto-determining term
 #' category was an option, but this is no longer supported, in part because it
-#' was potentially time consuming and sometimes inaccurate, in particular for
+#' was potentially time consuming and often inaccurate, in particular for
 #' the many post-composed subsumer terms returned by [subsumer_matrix()]. In the
 #' KB v2.0 API, auto-determining the category of a post-composed term is no
 #' longer supported. If the list of terms is legitimately of different categories,
 #' determine (and possibly correct) categories beforehand using [term_category()].
-#' In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, but
-#' this is no longer the case due to the inability to determine an accurate
-#' count for post-composed terms with the KB v2.0 API. This also means that the
-#' only supported value for the `as` parameter is "phenotype" since "entity" and
-#' "quality" were only supported for the "taxon_annotations" corpus.
+#' 
+#' In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, albeit
+#' it's implementation was very slow because it relied on potentially multiple individudal
+#' KB API queries for each term, and this in turn relied on the ability to break down
+#' post-composed expressions into their component terms and expressions, which is (at least
+#' currently) no longer possible. Once the KB API directly supports this corpus, it
+#' can be enabled here again.
 #' @param x a vector or list of one or more terms, either as IRIs or as term
 #'   objects.
-#' @param as the category or categories of the input terms (see [term_category()]).
-#'   Supported categories are "entity", "quality", and "phenotype". (At present,
-#'   support for "entity" and "quality" has been disabled as of v0.3.0, pending full support from the KB API.)
-#'   The value must either be a single category (applying to all terms), or a vector of
-#'   categories (of same length as `x`). The default is "phenotype".
-#' @param corpus the name of the corpus for which to determine frequencies.
-#'   Supported values are "taxon_annotations", "taxa", "gene_annotations", and
-#'   "genes". (At present, support for "gene_annotations" and "taxon_annotations" is disabled, pending support in
-#'   the Phenoscape KB API.)
-#'   The default is "taxa".
+#' @param as the category or categories (a.k.a. type) of the input terms (see [term_category()]).
+#'   Possible values are "anatomical_entity" (synonymous with "entity"), "quality", and
+#'   "phenotype". Unambiguous abbreviations are acceptable. The value must either be a
+#'   single category (applying to all terms), or a vector of categories (of same length as `x`).
+#'   The default is "phenotype".
+#' 
+#'   Note that at present, support by the KB API for "quality" remains pending and has thus been
+#'   disabled as of v0.3.0. Also, mixing different categories of terms is not yet supported, and
+#'   doing so will thus raise an error.
+#' @param corpus the name of the corpus for determining how to count, currently one of the following:
+#'   - "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
+#'   - "states" (counts character states),
+#'   - "taxa" (counts taxa),
+#'   - "gene_annotations" (counts phenotype annotations to genes), and
+#'   - "genes" (counts genes)
+#'   
+#'   Unambiguous abbreviations of corpus names are acceptable. The default is "taxa".
+#'   Note that at present "taxon_annotations" and "gene_annotations" are not yet
+#'   supported by the KB API and will thus result in an error.
 #' @param decodeIRI boolean. This parameter is deprecated (as of v0.3.x) and must be set
 #'  to FALSE (the default). If TRUE is passed an error will be raised. In v0.2.x
 #'  when TRUE this parameter would attempt to decode post-composed entity IRIs.
@@ -40,19 +51,29 @@
 #'  post-composed entity IRIs is no longer possible. Prior to v0.3.x, the default
 #'  value for this parameter was TRUE.
 #' @param ... additional query parameters to be passed to the function querying
-#'   for counts, see [pkb_args_to_query()]. Currently this is only used for
-#'   corpus "taxon_annotations", and the only useful parameter is `includeRels`,
-#'   which can be used to include historical and serial homologues in the counts.
-#'   It can also be used to always include parts for entity terms.
+#'   for counts, see [pkb_args_to_query()]. This is currently (as of v0.3.0) not
+#'   used.
 #' @return a vector of frequencies as floating point numbers (between zero
 #'   and 1.0), of the same length (and ordering) as the input list of terms.
 #' @examples
 #' phens <- get_phenotypes(entity = "basihyal bone")
-#' term_freqs(phens$id, as = "phenotype", corpus = "taxa")
-#' term_freqs(phens$id, as = "phenotype", corpus = "genes")
+#' # see which phenotypes we have:
+#' phens$label
+#' # frequencies by counting taxa:
+#' freqs.t <- term_freqs(phens$id, as = "phenotype", corpus = "taxa")
+#' freqs.t
+#' # we can convert this to absolute counts:
+#' freqs.t * corpus_size("taxa")
+#' # frequencies by counting character states:
+#' freqs.s <- term_freqs(phens$id, as = "phenotype", corpus = "states")
+#' freqs.s
+#' # and as absolute counts:
+#' freqs.s * corpus_size("states")
+#' # we can compare the absolute counts by computing a ratio
+#' freqs.s * corpus_size("states") / (freqs.t * corpus_size("taxa"))
 #' @export
 term_freqs <- function(x,
-                       as = c("phenotype", "entity", "quality"),
+                       as = c("phenotype", "entity", "anatomical_entity", "quality"),
                        corpus = c("taxa", "taxon_annotations", "gene_annotations", "genes", "states"),
                        decodeIRI = FALSE,
                        ...) {
@@ -65,7 +86,6 @@ term_freqs <- function(x,
     stop("'as' currently requires all values to be the same", call. = FALSE)
   if (corpus == "taxa" || corpus == "genes" || corpus == "states") {
     ctotal <- corpus_size(corpus = corpus)
-    corpusID <- paste0("http://kb.phenoscape.org/sim/", corpus)
     # for now 'as' must contain the same value so use the first one since
     # /similarity/frequency type field only allows one value
     ontology_terms_type <- as[1]
@@ -88,20 +108,27 @@ term_freqs <- function(x,
 #' Obtain the size of different corpora
 #'
 #' Obtains the size of a certain number of predefined corpora. The total size
-#' of a corpus is important for calculating term frequencies.
+#' of a corpus is important for calculating term frequencies. That is, for a given
+#' corpus, the possible range for any term frequency is between 0 and the corpus size.
 #'
 #' Corpus sizes are cached per session after they have first been obtained.
 #' Thus, if the Phenoscape KB changes, a session needs to be restarted to
 #' have those changes be reflected.
 #'
-#' @param corpus the name of the corpus, currently one of "taxon_annotations",
-#'   "taxa", "gene_annotations", and "genes". (At present "gene_annotations" is
-#'   pending support by the Phenoscape API.) Unambiguous abbreviations are
-#'   acceptable.
-#' @return the size of the specified corpus as an integer number.
+#' @param corpus the name of the corpus, currently one of the following:
+#'   - "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
+#'   - "states" (counts character states),
+#'   - "taxa" (counts taxa),
+#'   - "gene_annotations" (counts phenotype annotations to genes), and
+#'   - "genes" (counts genes)
+#'   
+#'   Note that at present "gene_annotations" is not yet supported by the Phenoscape API.
+#'   Unambiguous abbreviations of corpus names are acceptable.
+#' @return The total size of the specified corpus as an integer number.
 #' @examples
 #' corpus_size("taxa")
-#' corpus_size("taxon_annotations")
+#' corpus_size("states")
+#' corpus_size("genes")
 #' @export
 corpus_size <- local({
   .sizes <- list()

--- a/man/corpus_size.Rd
+++ b/man/corpus_size.Rd
@@ -5,21 +5,29 @@
 \title{Obtain the size of different corpora}
 \usage{
 corpus_size(
-  corpus = c("taxon_annotations", "taxa", "gene_annotations", "genes")
+  corpus = c("taxon_annotations", "taxa", "gene_annotations", "genes", "states")
 )
 }
 \arguments{
-\item{corpus}{the name of the corpus, currently one of "taxon_annotations",
-"taxa", "gene_annotations", and "genes". (At present "gene_annotations" is
-pending support by the Phenoscape API.) Unambiguous abbreviations are
-acceptable.}
+\item{corpus}{the name of the corpus, currently one of the following:
+\itemize{
+\item "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
+\item "states" (counts character states),
+\item "taxa" (counts taxa),
+\item "gene_annotations" (counts phenotype annotations to genes), and
+\item "genes" (counts genes)
+}
+
+Note that at present "gene_annotations" is not yet supported by the Phenoscape API.
+Unambiguous abbreviations of corpus names are acceptable.}
 }
 \value{
-the size of the specified corpus as an integer number.
+The total size of the specified corpus as an integer number.
 }
 \description{
 Obtains the size of a certain number of predefined corpora. The total size
-of a corpus is important for calculating term frequencies.
+of a corpus is important for calculating term frequencies. That is, for a given
+corpus, the possible range for any term frequency is between 0 and the corpus size.
 }
 \details{
 Corpus sizes are cached per session after they have first been obtained.
@@ -28,5 +36,6 @@ have those changes be reflected.
 }
 \examples{
 corpus_size("taxa")
-corpus_size("taxon_annotations")
+corpus_size("states")
+corpus_size("genes")
 }

--- a/man/term_freqs.Rd
+++ b/man/term_freqs.Rd
@@ -6,8 +6,8 @@
 \usage{
 term_freqs(
   x,
-  as = c("phenotype", "entity", "quality"),
-  corpus = c("taxa", "taxon_annotations", "gene_annotations", "genes"),
+  as = c("phenotype", "entity", "anatomical_entity", "quality"),
+  corpus = c("taxa", "taxon_annotations", "gene_annotations", "genes", "states"),
   decodeIRI = FALSE,
   ...
 )
@@ -16,17 +16,28 @@ term_freqs(
 \item{x}{a vector or list of one or more terms, either as IRIs or as term
 objects.}
 
-\item{as}{the category or categories of the input terms (see \code{\link[=term_category]{term_category()}}).
-Supported categories are "entity", "quality", and "phenotype". (At present,
-support for "entity" and "quality" has been disabled as of v0.3.0, pending full support from the KB API.)
-The value must either be a single category (applying to all terms), or a vector of
-categories (of same length as \code{x}). The default is "phenotype".}
+\item{as}{the category or categories (a.k.a. type) of the input terms (see \code{\link[=term_category]{term_category()}}).
+Possible values are "anatomical_entity" (synonymous with "entity"), "quality", and
+"phenotype". Unambiguous abbreviations are acceptable. The value must either be a
+single category (applying to all terms), or a vector of categories (of same length as \code{x}).
+The default is "phenotype".
 
-\item{corpus}{the name of the corpus for which to determine frequencies.
-Supported values are "taxon_annotations", "taxa", "gene_annotations", and
-"genes". (At present, support for "gene_annotations" and "taxon_annotations" is disabled, pending support in
-the Phenoscape KB API.)
-The default is "taxa".}
+Note that at present, support by the KB API for "quality" remains pending and has thus been
+disabled as of v0.3.0. Also, mixing different categories of terms is not yet supported, and
+doing so will thus raise an error.}
+
+\item{corpus}{the name of the corpus for determining how to count, currently one of the following:
+\itemize{
+\item "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
+\item "states" (counts character states),
+\item "taxa" (counts taxa),
+\item "gene_annotations" (counts phenotype annotations to genes), and
+\item "genes" (counts genes)
+}
+
+Unambiguous abbreviations of corpus names are acceptable. The default is "taxa".
+Note that at present "taxon_annotations" and "gene_annotations" are not yet
+supported by the KB API and will thus result in an error.}
 
 \item{decodeIRI}{boolean. This parameter is deprecated (as of v0.3.x) and must be set
 to FALSE (the default). If TRUE is passed an error will be raised. In v0.2.x
@@ -36,10 +47,8 @@ post-composed entity IRIs is no longer possible. Prior to v0.3.x, the default
 value for this parameter was TRUE.}
 
 \item{...}{additional query parameters to be passed to the function querying
-for counts, see \code{\link[=pkb_args_to_query]{pkb_args_to_query()}}. Currently this is only used for
-corpus "taxon_annotations", and the only useful parameter is \code{includeRels},
-which can be used to include historical and serial homologues in the counts.
-It can also be used to always include parts for entity terms.}
+for counts, see \code{\link[=pkb_args_to_query]{pkb_args_to_query()}}. This is currently (as of v0.3.0) not
+used.}
 }
 \value{
 a vector of frequencies as floating point numbers (between zero
@@ -47,7 +56,7 @@ and 1.0), of the same length (and ordering) as the input list of terms.
 }
 \description{
 Determines the frequencies for the given input list of terms, based on
-the selected corpus.
+the selected corpus and the type of the terms.
 }
 \details{
 Depending on the corpus selected, the frequencies are queried directly
@@ -59,19 +68,33 @@ has precomputed counts for corpora "taxa" and "genes".
 Term categories being accurate is vital for obtaining correct counts and
 thus frequencies. In earlier (<=0.2.x) releases, auto-determining term
 category was an option, but this is no longer supported, in part because it
-was potentially time consuming and sometimes inaccurate, in particular for
+was potentially time consuming and often inaccurate, in particular for
 the many post-composed subsumer terms returned by \code{\link[=subsumer_matrix]{subsumer_matrix()}}. In the
 KB v2.0 API, auto-determining the category of a post-composed term is no
 longer supported. If the list of terms is legitimately of different categories,
 determine (and possibly correct) categories beforehand using \code{\link[=term_category]{term_category()}}.
-In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, but
-this is no longer the case due to the inability to determine an accurate
-count for post-composed terms with the KB v2.0 API. This also means that the
-only supported value for the \code{as} parameter is "phenotype" since "entity" and
-"quality" were only supported for the "taxon_annotations" corpus.
+
+In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, albeit
+it's implementation was very slow because it relied on potentially multiple individudal
+KB API queries for each term, and this in turn relied on the ability to break down
+post-composed expressions into their component terms and expressions, which is (at least
+currently) no longer possible. Once the KB API directly supports this corpus, it
+can be enabled here again.
 }
 \examples{
 phens <- get_phenotypes(entity = "basihyal bone")
-term_freqs(phens$id, as = "phenotype", corpus = "taxa")
-term_freqs(phens$id, as = "phenotype", corpus = "genes")
+# see which phenotypes we have:
+phens$label
+# frequencies by counting taxa:
+freqs.t <- term_freqs(phens$id, as = "phenotype", corpus = "taxa")
+freqs.t
+# we can convert this to absolute counts:
+freqs.t * corpus_size("taxa")
+# frequencies by counting character states:
+freqs.s <- term_freqs(phens$id, as = "phenotype", corpus = "states")
+freqs.s
+# and as absolute counts:
+freqs.s * corpus_size("states")
+# we can compare the absolute counts by computing a ratio
+freqs.s * corpus_size("states") / (freqs.t * corpus_size("taxa"))
 }

--- a/tests/testthat/test-freqs.R
+++ b/tests/testthat/test-freqs.R
@@ -81,6 +81,10 @@ test_that("obtaining corpus size", {
   testthat::expect_gt(s, 100)
   testthat::expect_lt(s, 100000)
 
+  s <- corpus_size("states")
+  testthat::expect_gt(s, 100)
+  testthat::expect_lt(s, 100000)
+
   s <- corpus_size("taxon_annotations")
   testthat::expect_gt(s, 10000)
   testthat::expect_lt(s, 5000000)
@@ -101,6 +105,20 @@ test_that("obtaining/calculating term frequencies", {
   # check that the corpus defaults to "taxa"
   wt1 <- term_freqs(phens$id, as = "phenotype", corpus = "taxa")
   testthat::expect_identical(wt1, wt)
+
+  # check that we can use genes corpus with term_freqs
+  wt <- term_freqs(phens$id, as = "phenotype", corpus = "genes")
+  testthat::expect_is(wt, "numeric")
+  testthat::expect_length(wt, length(phens$id))
+  testthat::expect_true(all(wt >= 0))
+  testthat::expect_true(all(wt <= 1))
+
+  # check that we can use states corpus with term_freqs
+  wt <- term_freqs(phens$id, as = "phenotype", corpus = "states")
+  testthat::expect_is(wt, "numeric")
+  testthat::expect_length(wt, length(phens$id))
+  testthat::expect_true(all(wt >= 0))
+  testthat::expect_true(all(wt <= 1))
 
   # checking of error conditions
   testthat::expect_error(term_freqs(phens$id, as = "foobar"))

--- a/tests/testthat/test-freqs.R
+++ b/tests/testthat/test-freqs.R
@@ -102,21 +102,51 @@ test_that("obtaining/calculating term frequencies", {
   testthat::expect_true(all(wt >= 0))
   testthat::expect_true(all(wt <= 1))
 
-  # check that the corpus defaults to "taxa"
+  # check that the corpus defaults to "taxa" passing phenotype IRIS
   wt1 <- term_freqs(phens$id, as = "phenotype", corpus = "taxa")
   testthat::expect_identical(wt1, wt)
 
-  # check that we can use genes corpus with term_freqs
+  # check that we can use genes corpus with term_freqs passing phenotype IRIS
   wt <- term_freqs(phens$id, as = "phenotype", corpus = "genes")
   testthat::expect_is(wt, "numeric")
   testthat::expect_length(wt, length(phens$id))
   testthat::expect_true(all(wt >= 0))
   testthat::expect_true(all(wt <= 1))
 
-  # check that we can use states corpus with term_freqs
+  # check that we can use states corpus with term_freqs passing phenotype IRIS
   wt <- term_freqs(phens$id, as = "phenotype", corpus = "states")
   testthat::expect_is(wt, "numeric")
   testthat::expect_length(wt, length(phens$id))
+  testthat::expect_true(all(wt >= 0))
+  testthat::expect_true(all(wt <= 1))
+
+  entities <- find_term("basihyal bone")
+  # check that we can use taxa corpus with term_freqs passing entity IRIS
+  wt <- term_freqs(entities$id, as = "entity", corpus = "taxa")
+  testthat::expect_is(wt, "numeric")
+  testthat::expect_length(wt, length(entities$id))
+  testthat::expect_true(all(wt >= 0))
+  testthat::expect_true(all(wt <= 1))
+
+  # check that we can use genes corpus with term_freqs passing entity IRIS
+  wt <- term_freqs(entities$id, as = "entity", corpus = "genes")
+  testthat::expect_is(wt, "numeric")
+  testthat::expect_length(wt, length(entities$id))
+  testthat::expect_true(all(wt >= 0))
+  testthat::expect_true(all(wt <= 1))
+
+  # check that we can use states corpus with term_freqs passing entity IRIS
+  wt <- term_freqs(entities$id, as = "entity", corpus = "states")
+  testthat::expect_is(wt, "numeric")
+  testthat::expect_length(wt, length(entities$id))
+  testthat::expect_true(all(wt >= 0))
+  testthat::expect_true(all(wt <= 1))
+
+  # check that we can use states corpus with term_freqs passing entity IRIS with as vector
+  as_value = rep("entity", times=nrow(entities))
+  wt <- term_freqs(entities$id, as = as_value, corpus = "states")
+  testthat::expect_is(wt, "numeric")
+  testthat::expect_length(wt, length(entities$id))
   testthat::expect_true(all(wt >= 0))
   testthat::expect_true(all(wt <= 1))
 
@@ -127,8 +157,11 @@ test_that("obtaining/calculating term frequencies", {
   testthat::expect_error(term_freqs(phens$id, as = c(rep("phenotype",
                                                          times = nrow(phens)-1),
                                                      "auto")))
-  testthat::expect_error(term_freqs(phens$id, as = "entity", corpus = "taxa"))
   testthat::expect_error(term_freqs(phens$id, as = "quality", corpus = "taxa"))
+  # check that mismatched as values raises an error
+  as_value = rep("entity", times=nrow(entities))
+  as_value[1] <- "phenotype"
+  testthat::expect_error(term_freqs(entities$id, as = as_value, corpus = "states"))
 })
 
 test_that("term frequencies for post-comp subsumers of entities", {

--- a/tests/testthat/test-get-IRI.R
+++ b/tests/testthat/test-get-IRI.R
@@ -1,0 +1,8 @@
+context("finding terms")
+
+test_that("Test that anatomy_ontology_iris doesn't return PATO or ZP", {
+  skip_on_cran()
+  iris <- anatomy_ontology_iris()
+  expect_false("http://purl.obolibrary.org/obo/pato.owl" %in% iris)
+  expect_false("http://purl.obolibrary.org/obo/zp.owl" %in% iris)
+})

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -203,12 +203,7 @@ test_that("creating terminfo objects and extracting properties", {
   testthat::expect_is(obj, "terminfo")
   testthat::expect_true(is.terminfo(obj))
   testthat::expect_true(is_valid_terminfo(obj))
-
-  # optionally include classification
-  testthat::expect_false("classification" %in% names(obj))
-  obj <- as.terminfo(terms[1, "id"], withClassification = TRUE)
-  testthat::expect_true(is.terminfo(obj))
-  testthat::expect_true(is_valid_terminfo(obj))
+  # the current api automatically supplies classification data
   testthat::expect_true("classification" %in% names(obj))
   testthat::expect_equal(length(obj$classification), 3)
 
@@ -223,7 +218,6 @@ test_that("creating terminfo objects and extracting properties", {
   testthat::expect_is(obj, "terminfo")
   testthat::expect_true(is.terminfo(obj))
   testthat::expect_false(is_valid_terminfo(obj))
-  testthat::expect_null(obj$classification)
 
   # also works with data.frame as input
   obj <- as.terminfo(terms[1,])
@@ -272,8 +266,8 @@ test_that("as.terminfo withClassification can be controlled via an option", {
   term_iri <- find_term("basihyal bone", limit = 1)
   # create terminfo object
   ti <- as.terminfo(term_iri)
-  # classification should not be filled in
-  testthat::expect_false("classification" %in% names(ti))
+  # classification is filled in by default
+  testthat::expect_true("classification" %in% names(ti))
 
   # turn on the option to default withClassification to TRUE
   options(rphenoscape.fetch.classification = TRUE)
@@ -287,8 +281,8 @@ test_that("as.terminfo withClassification can be controlled via an option", {
   options(rphenoscape.fetch.classification = FALSE)
   # create terminfo object
   ti <- as.terminfo(term_iri)
-  # classification should not be filled in
-  testthat::expect_false("classification" %in% names(ti))
+  # classification is filled in by default
+  testthat::expect_true("classification" %in% names(ti))
 })
 
 test_that("as.terminfo can add classification to terminfo objects", {
@@ -296,8 +290,8 @@ test_that("as.terminfo can add classification to terminfo objects", {
   term_iri <- find_term("basihyal bone", limit = 1)
   # create terminfo object
   ti <- as.terminfo(term_iri)
-  # classification should not be filled in
-  testthat::expect_false("classification" %in% names(ti))
+  # classification is filled in by default
+  testthat::expect_true("classification" %in% names(ti))
   # run as.terminfo on a terminfo object requesting classification data
   ti <- as.terminfo(ti, withClassification = TRUE)
   # classification should be filled in

--- a/tests/testthat/test-semsim.R
+++ b/tests/testthat/test-semsim.R
@@ -63,12 +63,7 @@ test_that("Resnik similarity", {
   phens <- get_phenotypes("basihyal bone", taxon = "Cyprinidae")
   subs.mat <- subsumer_matrix(phens$id, .colnames = "label", .labels = phens$label,
                               preserveOrder = TRUE)
-  s <- unique(c(sample(1:nrow(subs.mat), size = 10),
-                match(phens$id, rownames(subs.mat))))
-  subs1 <- rownames(subs.mat)[s]
-  subs.mat1 <- subs.mat[s,]
-  rownames(subs.mat1) <- subs1
-  sm.ic <- resnik_similarity(subs.mat1,
+  sm.ic <- resnik_similarity(subs.mat,
                              wt_args = list(as = "phenotype", corpus = "taxa"))
   testthat::expect_equal(dim(sm.ic), c(nrow(phens), nrow(phens)))
   testthat::expect_true(all(sm.ic > 0))


### PR DESCRIPTION
Changes `phenoscape_api()` to return `https://dev.phenoscape.org/api/v2-beta`.
Fixes issue with `anatomy_ontology_iris()` returning PATO, and ZP.
Fixes errors with Resnik simlarity by removing sampling that occasionally caused problems.
Updates tests now that the KB API returns classification data in term info response.
Adds "states" to the `corpus` parameter for `corpus_size()` and `term_freqs()`.

Fixes #243
Fixes #245
Fixes #246
