### PR TITLE
Replaces taxa corpus with annotated-taxa/taxon-variation

### DIFF
--- a/R/term-weights.R
+++ b/R/term-weights.R
@@ -1,12 +1,12 @@
 #' Obtains term frequencies for the Phenoscape KB
 #'
 #' Determines the frequencies for the given input list of terms, based on
-#' the selected corpus and the type of the terms.
+#' the selected corpus and the type (category) of the terms.
 #'
 #' Depending on the corpus selected, the frequencies are queried directly
 #' from pre-computed counts through the KB API, or are calculated based on
 #' matching row counts obtained from query results. Currently, the Phenoscape KB
-#' has precomputed counts for corpora "annotated-taxa","taxon-variation", "genes" and "states".
+#' has precomputed counts for corpora "annotated-taxa","taxon-variation", "states", and "genes".
 #'
 #' @note
 #' Term categories being accurate is vital for obtaining correct counts and
@@ -18,12 +18,12 @@
 #' longer supported. If the list of terms is legitimately of different categories,
 #' determine (and possibly correct) categories beforehand using [term_category()].
 #' 
-#' In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, albeit
-#' it's implementation was very slow because it relied on potentially multiple individudal
-#' KB API queries for each term, and this in turn relied on the ability to break down
-#' post-composed expressions into their component terms and expressions, which is (at least
-#' currently) no longer possible. Once the KB API directly supports this corpus, it
-#' can be enabled here again.
+#' In earlier (<=0.2.x) releases one supported corpus was "taxon_annotations", albeit
+#' its implementation was very slow and potentially inaccurate because it relied on
+#' potentially multiple individudal KB API queries for each term, and this in turn
+#' relied on the ability to break down post-composed expressions into their component
+#' terms and expressions, which is (at least currently) no longer possible.
+#'
 #' @param x a vector or list of one or more terms, either as IRIs or as term
 #'   objects.
 #' @param as the category or categories (a.k.a. type) of the input terms (see [term_category()]).
@@ -36,15 +36,17 @@
 #'   disabled as of v0.3.0. Also, mixing different categories of terms is not yet supported, and
 #'   doing so will thus raise an error.
 #' @param corpus the name of the corpus for determining how to count, currently one of the following:
-#'   - "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
 #'   - "states" (counts character states),
-#'   - "taxon-variation" (counts taxa among variation profiles),
-#'   - "annotated-taxa" (counts taxa with annotations),
-#'   - "gene_annotations" (counts phenotype annotations to genes), and
+#'   - "taxon-variation" (counts taxa with variation profiles, and thus does not include terminal
+#'      and other taxa that do not have child taxa with phenotype annotations),
+#'   - "annotated-taxa" (counts taxa with phenotype annotations, and thus primarily those terminal
+#'      taxa that have annotations),
+#'   - "taxon-annotations" (counts phenotype annotations to character states and thus taxa),
+#'   - "gene-annotations" (counts phenotype annotations to genes or alleles), and
 #'   - "genes" (counts genes)
 #'   
 #'   Unambiguous abbreviations of corpus names are acceptable. The default is "taxon-variation".
-#'   Note that at present "taxon_annotations" and "gene_annotations" are not yet
+#'   Note that at present "taxon-annotations" and "gene-annotations" are not yet
 #'   supported by the KB API and will thus result in an error.
 #'
 #'   Note that previously "taxa" was allowed as a corpus, but is no longer supported.
@@ -79,7 +81,7 @@
 #' @export
 term_freqs <- function(x,
                        as = c("phenotype", "entity", "anatomical_entity", "quality"),
-                       corpus = c("taxon-variation", "annotated-taxa", "taxon_annotations", "gene_annotations", "genes", "states"),
+                       corpus = c("taxon-variation", "annotated-taxa", "taxon-annotations", "states", "gene-annotations", "genes"),
                        decodeIRI = FALSE,
                        ...) {
   as <- match.arg(as, several.ok = TRUE)
@@ -120,19 +122,8 @@ term_freqs <- function(x,
 #' Thus, if the Phenoscape KB changes, a session needs to be restarted to
 #' have those changes be reflected.
 #'
-#' @param corpus the name of the corpus, currently one of the following:
-#'   - "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
-#'   - "states" (counts character states),
-#'   - "taxon-variation" (counts taxa among variation profiles),
-#'   - "annotated-taxa" (counts taxa with annotations),
-#'   - "gene_annotations" (counts phenotype annotations to genes), and
-#'   - "genes" (counts genes)
-#'   
-#'   Note that at present "gene_annotations" is not yet supported by the Phenoscape API.
-#'   Unambiguous abbreviations of corpus names are acceptable.
+#' @param corpus the name of the corpus, see [term_freqs()] for allowed values.
 #'
-#'   Note that previously "taxa" was allowed as a corpus, but is no longer supported.
-#'   The "taxon-variation" corpus is the equivalent of the deprecated "taxa" corpus.
 #' @return The total size of the specified corpus as an integer number.
 #' @examples
 #' corpus_size("taxon-variation")
@@ -142,14 +133,14 @@ term_freqs <- function(x,
 #' @export
 corpus_size <- local({
   .sizes <- list()
-  function(corpus = c("taxon_annotations", "taxon-variation", "annotated-taxa", "gene_annotations", "genes", "states")) {
+  function(corpus = c("taxon-annotations", "taxon-variation", "annotated-taxa", "gene-annotations", "genes", "states")) {
     corpus <- match.arg(corpus)
     if (is.null(.sizes[[corpus]])) {
       if (corpus == "taxon-variation" || corpus == "annotated-taxa" || corpus == "genes"|| corpus == "states") {
         res <- get_json_data(pkb_api("/similarity/corpus_size"),
                              query = list(corpus = corpus))
         .sizes[[corpus]] <- res$total
-      } else if (corpus == "taxon_annotations") {
+      } else if (corpus == "taxon-annotations") {
         res <- get_json_data(pkb_api("/taxon/annotations"), list(total = TRUE))
         .sizes[[corpus]] <- res$total
       } else {

--- a/man/corpus_size.Rd
+++ b/man/corpus_size.Rd
@@ -5,7 +5,8 @@
 \title{Obtain the size of different corpora}
 \usage{
 corpus_size(
-  corpus = c("taxon_annotations", "taxa", "gene_annotations", "genes", "states")
+  corpus = c("taxon_annotations", "taxon-variation", "annotated-taxa",
+    "gene_annotations", "genes", "states")
 )
 }
 \arguments{
@@ -13,13 +14,17 @@ corpus_size(
 \itemize{
 \item "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
 \item "states" (counts character states),
-\item "taxa" (counts taxa),
+\item "taxon-variation" (counts taxa among variation profiles),
+\item "annotated-taxa" (counts taxa with annotations),
 \item "gene_annotations" (counts phenotype annotations to genes), and
 \item "genes" (counts genes)
 }
 
 Note that at present "gene_annotations" is not yet supported by the Phenoscape API.
-Unambiguous abbreviations of corpus names are acceptable.}
+Unambiguous abbreviations of corpus names are acceptable.
+
+Note that previously "taxa" was allowed as a corpus, but is no longer supported.
+The "taxon-variation" corpus is the equivalent of the deprecated "taxa" corpus.}
 }
 \value{
 The total size of the specified corpus as an integer number.
@@ -35,7 +40,8 @@ Thus, if the Phenoscape KB changes, a session needs to be restarted to
 have those changes be reflected.
 }
 \examples{
-corpus_size("taxa")
+corpus_size("taxon-variation")
+corpus_size("annotated-taxa")
 corpus_size("states")
 corpus_size("genes")
 }

--- a/man/corpus_size.Rd
+++ b/man/corpus_size.Rd
@@ -5,26 +5,12 @@
 \title{Obtain the size of different corpora}
 \usage{
 corpus_size(
-  corpus = c("taxon_annotations", "taxon-variation", "annotated-taxa",
-    "gene_annotations", "genes", "states")
+  corpus = c("taxon-annotations", "taxon-variation", "annotated-taxa",
+    "gene-annotations", "genes", "states")
 )
 }
 \arguments{
-\item{corpus}{the name of the corpus, currently one of the following:
-\itemize{
-\item "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
-\item "states" (counts character states),
-\item "taxon-variation" (counts taxa among variation profiles),
-\item "annotated-taxa" (counts taxa with annotations),
-\item "gene_annotations" (counts phenotype annotations to genes), and
-\item "genes" (counts genes)
-}
-
-Note that at present "gene_annotations" is not yet supported by the Phenoscape API.
-Unambiguous abbreviations of corpus names are acceptable.
-
-Note that previously "taxa" was allowed as a corpus, but is no longer supported.
-The "taxon-variation" corpus is the equivalent of the deprecated "taxa" corpus.}
+\item{corpus}{the name of the corpus, see \code{\link[=term_freqs]{term_freqs()}} for allowed values.}
 }
 \value{
 The total size of the specified corpus as an integer number.

--- a/man/term_freqs.Rd
+++ b/man/term_freqs.Rd
@@ -7,7 +7,8 @@
 term_freqs(
   x,
   as = c("phenotype", "entity", "anatomical_entity", "quality"),
-  corpus = c("taxa", "taxon_annotations", "gene_annotations", "genes", "states"),
+  corpus = c("taxon-variation", "annotated-taxa", "taxon_annotations",
+    "gene_annotations", "genes", "states"),
   decodeIRI = FALSE,
   ...
 )
@@ -30,14 +31,18 @@ doing so will thus raise an error.}
 \itemize{
 \item "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
 \item "states" (counts character states),
-\item "taxa" (counts taxa),
+\item "taxon-variation" (counts taxa among variation profiles),
+\item "annotated-taxa" (counts taxa with annotations),
 \item "gene_annotations" (counts phenotype annotations to genes), and
 \item "genes" (counts genes)
 }
 
-Unambiguous abbreviations of corpus names are acceptable. The default is "taxa".
+Unambiguous abbreviations of corpus names are acceptable. The default is "taxon-variation".
 Note that at present "taxon_annotations" and "gene_annotations" are not yet
-supported by the KB API and will thus result in an error.}
+supported by the KB API and will thus result in an error.
+
+Note that previously "taxa" was allowed as a corpus, but is no longer supported.
+The "taxon-variation" corpus is the equivalent of the deprecated "taxa" corpus.}
 
 \item{decodeIRI}{boolean. This parameter is deprecated (as of v0.3.x) and must be set
 to FALSE (the default). If TRUE is passed an error will be raised. In v0.2.x
@@ -62,7 +67,7 @@ the selected corpus and the type of the terms.
 Depending on the corpus selected, the frequencies are queried directly
 from pre-computed counts through the KB API, or are calculated based on
 matching row counts obtained from query results. Currently, the Phenoscape KB
-has precomputed counts for corpora "taxa" and "genes".
+has precomputed counts for corpora "annotated-taxa","taxon-variation", "genes" and "states".
 }
 \note{
 Term categories being accurate is vital for obtaining correct counts and
@@ -86,15 +91,15 @@ phens <- get_phenotypes(entity = "basihyal bone")
 # see which phenotypes we have:
 phens$label
 # frequencies by counting taxa:
-freqs.t <- term_freqs(phens$id, as = "phenotype", corpus = "taxa")
+freqs.t <- term_freqs(phens$id, as = "phenotype", corpus = "taxon-variation")
 freqs.t
 # we can convert this to absolute counts:
-freqs.t * corpus_size("taxa")
+freqs.t * corpus_size("taxon-variation")
 # frequencies by counting character states:
 freqs.s <- term_freqs(phens$id, as = "phenotype", corpus = "states")
 freqs.s
 # and as absolute counts:
 freqs.s * corpus_size("states")
 # we can compare the absolute counts by computing a ratio
-freqs.s * corpus_size("states") / (freqs.t * corpus_size("taxa"))
+freqs.s * corpus_size("states") / (freqs.t * corpus_size("taxon-variation"))
 }

--- a/man/term_freqs.Rd
+++ b/man/term_freqs.Rd
@@ -7,8 +7,8 @@
 term_freqs(
   x,
   as = c("phenotype", "entity", "anatomical_entity", "quality"),
-  corpus = c("taxon-variation", "annotated-taxa", "taxon_annotations",
-    "gene_annotations", "genes", "states"),
+  corpus = c("taxon-variation", "annotated-taxa", "taxon-annotations", "states",
+    "gene-annotations", "genes"),
   decodeIRI = FALSE,
   ...
 )
@@ -29,16 +29,18 @@ doing so will thus raise an error.}
 
 \item{corpus}{the name of the corpus for determining how to count, currently one of the following:
 \itemize{
-\item "taxon_annotations" (counts phenotype annotations to character states and thus taxa),
 \item "states" (counts character states),
-\item "taxon-variation" (counts taxa among variation profiles),
-\item "annotated-taxa" (counts taxa with annotations),
-\item "gene_annotations" (counts phenotype annotations to genes), and
+\item "taxon-variation" (counts taxa with variation profiles, and thus does not include terminal
+and other taxa that do not have child taxa with phenotype annotations),
+\item "annotated-taxa" (counts taxa with phenotype annotations, and thus primarily those terminal
+taxa that have annotations),
+\item "taxon-annotations" (counts phenotype annotations to character states and thus taxa),
+\item "gene-annotations" (counts phenotype annotations to genes or alleles), and
 \item "genes" (counts genes)
 }
 
 Unambiguous abbreviations of corpus names are acceptable. The default is "taxon-variation".
-Note that at present "taxon_annotations" and "gene_annotations" are not yet
+Note that at present "taxon-annotations" and "gene-annotations" are not yet
 supported by the KB API and will thus result in an error.
 
 Note that previously "taxa" was allowed as a corpus, but is no longer supported.
@@ -61,13 +63,13 @@ and 1.0), of the same length (and ordering) as the input list of terms.
 }
 \description{
 Determines the frequencies for the given input list of terms, based on
-the selected corpus and the type of the terms.
+the selected corpus and the type (category) of the terms.
 }
 \details{
 Depending on the corpus selected, the frequencies are queried directly
 from pre-computed counts through the KB API, or are calculated based on
 matching row counts obtained from query results. Currently, the Phenoscape KB
-has precomputed counts for corpora "annotated-taxa","taxon-variation", "genes" and "states".
+has precomputed counts for corpora "annotated-taxa","taxon-variation", "states", and "genes".
 }
 \note{
 Term categories being accurate is vital for obtaining correct counts and
@@ -79,12 +81,11 @@ KB v2.0 API, auto-determining the category of a post-composed term is no
 longer supported. If the list of terms is legitimately of different categories,
 determine (and possibly correct) categories beforehand using \code{\link[=term_category]{term_category()}}.
 
-In earlier (<=0.2.x) releases the "taxon_annotations" corpus was supported, albeit
-it's implementation was very slow because it relied on potentially multiple individudal
-KB API queries for each term, and this in turn relied on the ability to break down
-post-composed expressions into their component terms and expressions, which is (at least
-currently) no longer possible. Once the KB API directly supports this corpus, it
-can be enabled here again.
+In earlier (<=0.2.x) releases one supported corpus was "taxon_annotations", albeit
+its implementation was very slow and potentially inaccurate because it relied on
+potentially multiple individudal KB API queries for each term, and this in turn
+relied on the ability to break down post-composed expressions into their component
+terms and expressions, which is (at least currently) no longer possible.
 }
 \examples{
 phens <- get_phenotypes(entity = "basihyal bone")

--- a/tests/testthat/test-freqs.R
+++ b/tests/testthat/test-freqs.R
@@ -89,12 +89,12 @@ test_that("obtaining corpus size", {
   testthat::expect_gt(s, 100)
   testthat::expect_lt(s, 100000)
 
-  s <- corpus_size("taxon_annotations")
+  s <- corpus_size("taxon-annotations")
   testthat::expect_gt(s, 10000)
   testthat::expect_lt(s, 5000000)
   testthat::expect_equal(corpus_size(), s)
 
-  testthat::expect_error(corpus_size("gene_annotations"))
+  testthat::expect_error(corpus_size("gene-annotations"))
   testthat::expect_error(corpus_size("foobar"))
 })
 
@@ -182,8 +182,8 @@ test_that("term frequencies for post-comp subsumers of entities", {
   # reduce to post-comps and test a handful
   onts <- obo_prefix(subs)
   subs <- subs[is.na(onts)]
-  # Expect an error since the taxon_annotations corpus is no longer supported.
-  testthat::expect_error(term_freqs(subs, as = "entity", corpus = "taxon_annotations"), 
-                         "corpus 'taxon_annotations' is currently unsupported")
+  # Expect an error since the taxon-annotations corpus is not yet supported.
+  testthat::expect_error(term_freqs(subs, as = "entity", corpus = "taxon-annotations"), 
+                         "corpus 'taxon-annotations' is currently unsupported")
 })
 

--- a/tests/testthat/test-freqs.R
+++ b/tests/testthat/test-freqs.R
@@ -73,7 +73,11 @@ test_that("success rate for entity subsumer terms", {
 })
 
 test_that("obtaining corpus size", {
-  s <- corpus_size("taxa")
+  s <- corpus_size("taxon-variation")
+  testthat::expect_gt(s, 100)
+  testthat::expect_lt(s, 10000)
+
+  s <- corpus_size("annotated-taxa")
   testthat::expect_gt(s, 100)
   testthat::expect_lt(s, 10000)
 
@@ -102,8 +106,8 @@ test_that("obtaining/calculating term frequencies", {
   testthat::expect_true(all(wt >= 0))
   testthat::expect_true(all(wt <= 1))
 
-  # check that the corpus defaults to "taxa" passing phenotype IRIS
-  wt1 <- term_freqs(phens$id, as = "phenotype", corpus = "taxa")
+  # check that the corpus defaults to "taxon-variation" passing phenotype IRIS
+  wt1 <- term_freqs(phens$id, as = "phenotype", corpus = "taxon-variation")
   testthat::expect_identical(wt1, wt)
 
   # check that we can use genes corpus with term_freqs passing phenotype IRIS
@@ -122,7 +126,7 @@ test_that("obtaining/calculating term frequencies", {
 
   entities <- find_term("basihyal bone")
   # check that we can use taxa corpus with term_freqs passing entity IRIS
-  wt <- term_freqs(entities$id, as = "entity", corpus = "taxa")
+  wt <- term_freqs(entities$id, as = "entity", corpus = "taxon-variation")
   testthat::expect_is(wt, "numeric")
   testthat::expect_length(wt, length(entities$id))
   testthat::expect_true(all(wt >= 0))
@@ -150,6 +154,14 @@ test_that("obtaining/calculating term frequencies", {
   testthat::expect_true(all(wt >= 0))
   testthat::expect_true(all(wt <= 1))
 
+  # check that we can use annotated-taxa corpus with term_freqs passing entity IRIS with as vector
+  as_value = rep("entity", times=nrow(entities))
+  wt <- term_freqs(entities$id, as = as_value, corpus = "annotated-taxa")
+  testthat::expect_is(wt, "numeric")
+  testthat::expect_length(wt, length(entities$id))
+  testthat::expect_true(all(wt >= 0))
+  testthat::expect_true(all(wt <= 1))
+  
   # checking of error conditions
   testthat::expect_error(term_freqs(phens$id, as = "foobar"))
   testthat::expect_error(term_freqs(phens$id, corpus = "foobar"))
@@ -157,7 +169,7 @@ test_that("obtaining/calculating term frequencies", {
   testthat::expect_error(term_freqs(phens$id, as = c(rep("phenotype",
                                                          times = nrow(phens)-1),
                                                      "auto")))
-  testthat::expect_error(term_freqs(phens$id, as = "quality", corpus = "taxa"))
+  testthat::expect_error(term_freqs(phens$id, as = "quality", corpus = "taxon-variation"))
   # check that mismatched as values raises an error
   as_value = rep("entity", times=nrow(entities))
   as_value[1] <- "phenotype"

--- a/tests/testthat/test-semsim.R
+++ b/tests/testthat/test-semsim.R
@@ -64,11 +64,11 @@ test_that("Resnik similarity", {
   subs.mat <- subsumer_matrix(phens$id, .colnames = "label", .labels = phens$label,
                               preserveOrder = TRUE)
   sm.ic <- resnik_similarity(subs.mat,
-                             wt_args = list(as = "phenotype", corpus = "taxa"))
+                             wt_args = list(as = "phenotype", corpus = "taxon-variation"))
   testthat::expect_equal(dim(sm.ic), c(nrow(phens), nrow(phens)))
   testthat::expect_true(all(sm.ic > 0))
-  testthat::expect_true(all(sm.ic <= -log10(1 / corpus_size("taxa"))))
-  termICs <- -log10(term_freqs(phens$id, as = "phenotype", corpus = "taxa"))
+  testthat::expect_true(all(sm.ic <= -log10(1 / corpus_size("taxon-variation"))))
+  termICs <- -log10(term_freqs(phens$id, as = "phenotype", corpus = "taxon-variation"))
   testthat::expect_equivalent(diag(sm.ic), termICs)
 })
 
@@ -132,7 +132,7 @@ test_that("profile similarity with Resnik", {
     if (length(phen$eqs$related_entities) > 0) "relational" else "monadic"
   }))
 
-  freqs <- term_freqs(rownames(subs.mat), as = "phenotype", corpus = "taxa")
+  freqs <- term_freqs(rownames(subs.mat), as = "phenotype", corpus = "taxon-variation")
   toKeep <- ! (is.na(freqs) | freqs == 0)
   freqs <- freqs[toKeep]
   subs.mat <- subs.mat[toKeep,]
@@ -141,7 +141,7 @@ test_that("profile similarity with Resnik", {
   testthat::expect_equal(colnames(sm), levels(phens.f))
   testthat::expect_equal(rownames(sm), levels(phens.f))
   testthat::expect_gt(min(sm), 0)
-  testthat::expect_lte(max(sm), -log10(1 / corpus_size("taxa")))
+  testthat::expect_lte(max(sm), -log10(1 / corpus_size("taxon-variation")))
 
   # for Resnik as metric, group-wise is the same as pair-wise with maxIC
   sm1 <- profile_similarity(resnik_similarity, subs.mat, wt = -log10(freqs),


### PR DESCRIPTION
The KB API corpus parameter has replaced the "taxa" value with "annotated-taxa" and "taxon-variation". Users can now supply these two values where previously they passed the "taxa" corpus. Occurrences of "taxa" have been replaced by "annotated-taxa".

Fixes #253