### PR TITLE
Fixes CircleCI tests cache problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ steps: &steps
   steps:
     - restore_cache:
         keys:
-          - cache-{{ .Environment.CIRCLE_JOB }}
+          - cache-{{ .Environment.CACHE_VERSION }}-{{ .Environment.CIRCLE_JOB }}
     - checkout
     - run:
         name: Install package dependencies
@@ -18,7 +18,7 @@ steps: &steps
     - store_artifacts:
         path: rphenoscape.Rcheck/
     - save_cache:
-        key: cache-{{ .Environment.CIRCLE_JOB }}
+        key: cache-{{ .Environment.CACHE_VERSION }}-{{ .Environment.CIRCLE_JOB }}
         paths:
           - "/usr/local/lib/R/site-library"
 


### PR DESCRIPTION
Adds CircleCI CACHE_VERSION environment variable to allow
running tests with a clean cache. The CACHE_VERSION Environment
variable can be changed within the CircleCI project settings
to a higher number to clear the cache.
https://support.circleci.com/hc/en-us/articles/115015426888-Clear-Project-Dependency-Cache

This was to fix a problem where a new version of the R container
failed to install dependencies:
```
> devtools::install_deps(dep = TRUE)
Error in dyn.load(file, DLLpath = DLLpath, ...) :
  unable to load shared object '/usr/local/lib/R/site-library/stringi/libs/stringi.so':
  libicui18n.so.66: cannot open shared object file: No such file or directory
Calls: loadNamespace ... namespaceImport -> loadNamespace -> library.dynam -> dyn.load
Execution halted
```

Fixes https://github.com/phenoscape/rphenoscape/issues/268