### PR TITLE
Improves phenotype print display

### DIFF
--- a/R/phen_obj.R
+++ b/R/phen_obj.R
@@ -237,7 +237,7 @@ print.phenotype <- function(x, ...) {
         sep = "")
     if (length(x$eqs$related_entities) > 0) {
       l_r <- get_term_label(x$eqs$related_entities, preserveOrder = TRUE)
-      cat("Towards:\n    ",
+      cat("Related entities:\n    ",
           paste(l_r$label, " <", l_r$id, ">", collapse = "\n    ", sep = ""),
           "\n", sep = "")
     } else

--- a/tests/testthat/test-phenotypes.R
+++ b/tests/testthat/test-phenotypes.R
@@ -197,6 +197,7 @@ test_that("pretty-printing phenotype objects", {
                           paste("<", obj$eqs$entities[1], ">", sep = ""))
   testthat::expect_output(print(obj),
                           paste("<", obj$eqs$qualities[1], ">", sep = ""))
+  testthat::expect_output(print(obj), "Related entities")
 
   # does not bomb for an invalid phenotype object
   testthat::expect_warning(foo <- as.phenotype("http://foo"))


### PR DESCRIPTION
Replaces 'Towards' with 'Related entities" the printed output of phenotype.

Fixes #250