### PR TITLE
Adds includeRelatedSynonyms to taxon_info()

### DIFF
--- a/R/get_IRI.R
+++ b/R/get_IRI.R
@@ -117,6 +117,8 @@ find_term <- function(query,
 #' @param exactOnly logical. Whether to require an exact match. If TRUE, only
 #'   the first exact match is returned. Default is FALSE.
 #' @param nomatch the value to return if there is no match, by default NA.
+#' @param includeRelatedSynonyms logical: optional. If TRUE when looking up
+#'   the IRI, text will be matched against related synonyms as well.
 #' @param verbose logical: optional. If TRUE, prints messages prior to potentially
 #'   time-consuming operations. Default is FALSE.
 #' @return The IRI if a match is found.
@@ -124,6 +126,7 @@ find_term <- function(query,
 get_term_iri <- function(text, as,
                          exactOnly = FALSE,
                          nomatch = NA,
+                         includeRelatedSynonyms = FALSE,
                          verbose = FALSE) {
   # if the query string is already a HTTP URI, return it as the result
   if (startsWith(text, "http://") || startsWith(text, "https://")) return(text)
@@ -135,15 +138,22 @@ get_term_iri <- function(text, as,
     else if (startsWith(as, "anatom"))
       as <- anatomy_ontology_iris()
   }
+
+  matchBy <- c("rdfs:label", "oboInOwl:hasExactSynonym", "oboInOwl:NarrowSynonym",  "oboInOwl:hasBroadSynonym")
+  if (includeRelatedSynonyms) {
+    matchBy <- append(matchBy, "oboInOwl:hasRelatedSynonym")
+  }
   if (exactOnly)
     iri_df <- find_term(query = text,
                         definedBy = as,
                         nomatch = nomatch,
+                        matchBy = matchBy,
                         matchTypes = c("exact"), limit = 20, verbose = verbose)
   else
     iri_df <- find_term(query = text,
                         definedBy = as,
                         nomatch = nomatch,
+                        matchBy = matchBy,
                         limit = 20, verbose = verbose)
 
   if (identical(iri_df, nomatch)) {

--- a/R/terms.R
+++ b/R/terms.R
@@ -10,6 +10,8 @@
 #'   For `taxon_info` this can also be a list (or vector) of terms (taxa).
 #' @param taxon character, the NCBI taxon name or corresponding NCBITaxon
 #'   ontology IRI for which to match the gene name.
+#' @param includeRelatedSynonyms logical: optional. If TRUE when looking up
+#'   the IRI for a term label, matches against related synonyms will be included.
 #' @param verbose logical, whether informative messages should be printed. The
 #'   default is `FALSE`.
 #' @return A data.frame, with at least columns "id" and "label".
@@ -26,14 +28,16 @@
 #'   or 'partial').
 #' @examples
 #' taxon_info("Coralliozetus")
+#' taxon_info("Chrosomus eos", includeRelatedSynonyms = TRUE)
 #' anatomy_term_info("basihyal bone")
 #' gene_info("socs5")
 #'
 #' @export
 #' @rdname terms
-taxon_info <- function(term, verbose=FALSE) {
+taxon_info <- function(term, includeRelatedSynonyms = FALSE, verbose=FALSE) {
   iriList <- sapply(term,
                     get_term_iri, as = "taxon",  verbose = verbose,
+                    includeRelatedSynonyms = includeRelatedSynonyms,
                     USE.NAMES = FALSE)
   if (length(iriList) == 1 && is.na(iriList)) return(invisible(NA))
 

--- a/tests/testthat/test-pk.R
+++ b/tests/testthat/test-pk.R
@@ -70,6 +70,16 @@ test_that("taxon details works", {
   expect_false(all(is.na(dd$common_name)))
 })
 
+test_that("taxon info can use includeRelatedSynonyms", {
+  expect_warning(d <- taxon_info("Chrosomus eos"))
+  expect_true(is.na(d))
+  expect_warning(d2 <- taxon_info("Chrosomus eos", includeRelatedSynonyms = FALSE))
+  expect_true(is.na(d2))
+  expect_warning(d3 <- taxon_info("Chrosomus eos", includeRelatedSynonyms = TRUE))
+  expect_equal(nrow(d3), 1)
+  expect_equal(d3$id, "http://purl.obolibrary.org/obo/VTO_0040309")
+})
+
 test_that("Test deprecated taxon details", {
   skip_on_cran()
   expect_warning(a <- pk_taxon_detail("Coralliozetus"))
@@ -125,6 +135,17 @@ test_that("Test retrieving IRI", {
   expect_warning(tiri <- get_term_iri("anatomical structure", as = NA, exactOnly = TRUE))
   expect_is(tiri, "character")
   expect_true(startsWith(tiri, "http://purl.obolibrary.org/obo/"))
+})
+
+test_that("Test retrieving IRI using includeRelatedSynonyms", {
+  expect_warning(IRI <- get_term_iri("Chrosomus eos", as="taxon"))
+  expect_equal(IRI, NA)
+
+  expect_warning(IRI <- get_term_iri("Chrosomus eos", as = "taxon", includeRelatedSynonyms = TRUE))
+  expect_equal(IRI, "http://purl.obolibrary.org/obo/VTO_0040309")
+
+  expect_warning(IRI <- get_term_iri("Chrosomus eos", as = "taxon", includeRelatedSynonyms = FALSE))
+  expect_equal(IRI, NA)
 })
 
 test_that("Test finding terms without a limit", {


### PR DESCRIPTION
Adds includeRelatedSynonyms boolean parameter that will include hasRelatedSynonym when looking up the term.
Also adds this to get_term_iri().

Fixes #280